### PR TITLE
Ignore JDK files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,42 +6,6 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
-# User-specific stuff
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/**/usage.statistics.xml
-.idea/**/dictionaries
-.idea/**/shelf
-
-# Generated files
-.idea/**/contentModel.xml
-
-# Sensitive or high-churn files
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-.idea/**/dbnavigator.xml
-
-# Gradle
-.idea/**/gradle.xml
-.idea/**/libraries
-
-# Gradle and Maven with auto-import
-# When using Gradle or Maven with auto-import, you should exclude module files,
-# since they will be recreated, and may cause churn.  Uncomment if using
-# auto-import.
-# .idea/artifacts
-# .idea/compiler.xml
-# .idea/jarRepositories.xml
-# .idea/modules.xml
-# .idea/*.iml
-# .idea/modules
-# *.iml
-# *.ipr
-
 # CMake
 cmake-build-*/
 

--- a/.gitignore
+++ b/.gitignore
@@ -125,7 +125,6 @@ hs_err_pid*
 
 ### JDK ###
 .idea
-out
 server
 *.vsix
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -127,12 +127,9 @@ hs_err_pid*
 .idea
 out
 server
-node_modules
 *.vsix
 .DS_Store
-.vscode-test
 undefined
-dist
 bin/
 .settings
 .classpath

--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,22 @@ fabric.properties
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+### JDK ###
+.idea
+out
+server
+node_modules
+*.vsix
+.DS_Store
+.vscode-test
+undefined
+dist
+bin/
+.settings
+.classpath
+.project
+.factorypath
+
 ### Maven ###
 target/
 pom.xml.tag


### PR DESCRIPTION
update the gitignore file to ignore JDK files as well. JDK is useful for local Java programming on chromebooks. The meta data created by JDK might cause errors when working in non-Linux environments. The gitignore additions are taken from [here](https://github.com/Obinnabii/my-portfolio/blob/master/.gitignore)  


@billyeh linked me to a page with a fully set up gitignore [here](https://github.com/redhat-developer/vscode-java/blob/master/.gitignore). The link above is to the gitignore that worked on my portfolio.