### PR TITLE
Add backend support for project previews

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,22 @@
       <artifactId>github-api</artifactId>
       <version>1.114</version>
     </dependency>
+
+    <!-- https://mvnrepository.com/artifact/junit/junit -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- https://mvnrepository.com/artifact/org.mockito/mockito-all -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/google/opensesame/projects/ProjectPreview.java
+++ b/src/main/java/com/google/opensesame/projects/ProjectPreview.java
@@ -1,0 +1,102 @@
+package com.google.opensesame.projects;
+
+import com.google.opensesame.github.GitHubGetter;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GitHub;
+
+public class ProjectPreview {
+  /**
+   * Creates a ProjectPreview object from a set of project properties.
+   *
+   * @param properties The properties of a project entity. This can come directly from a datastore
+   *     entity, as datastore entities inherit a getProperty() method from PropertyContainer:
+   *     https://cloud.google.com/appengine/docs/standard/java/javadoc/com/google/appengine/api/datastore/Entity
+   * @return Returns the created ProjectPreview.
+   * @throws IOException Throws when there is an error communicating with the GitHub API.
+   */
+  public static ProjectPreview fromProperties(Map<String, Object> properties) throws IOException {
+    GitHub gitHub = GitHubGetter.getGitHub();
+    GHRepository repository = gitHub.getRepository((String) properties.get("repositoryName"));
+
+    return fromPropertiesAndRepository(properties, repository);
+  }
+
+  /**
+   * Creates a ProjectPreview object from a set of project properties and it's associated GitHub
+   * repository.
+   *
+   * @param properties The properties of a project. This will most likely come from a datastore
+   *     entity.
+   * @param repository The GitHub repository associated with the project.
+   * @return Returns the created ProjectPreview
+   * @throws IOException Throws when there is an error communicating with the GitHub API.
+   */
+  public static ProjectPreview fromPropertiesAndRepository(
+      Map<String, Object> properties, GHRepository repository) throws IOException {
+    return new ProjectPreview(
+        repository.getName(),
+        repository.getDescription(),
+        repository.listTopics(),
+        repository.getLanguage(),
+        (int) properties.get("numMentors"),
+        repository);
+  }
+
+  private final String name;
+  private final String description;
+  private final List<String> topicTags;
+  private final String primaryLanguage;
+  private final int numMentors;
+  private final transient GHRepository repository;
+
+  /**
+   * Creates a new ProjectPreview object.
+   *
+   * @param name
+   * @param description
+   * @param topicTags
+   * @param numMentors
+   * @param repository
+   */
+  public ProjectPreview(
+      String name,
+      String description,
+      List<String> topicTags,
+      String primaryLanguage,
+      int numMentors,
+      GHRepository repository) {
+    this.name = name;
+    this.description = description;
+    this.topicTags = topicTags;
+    this.primaryLanguage = primaryLanguage;
+    this.numMentors = numMentors;
+    this.repository = repository;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public List<String> getTopicTags() {
+    return topicTags;
+  }
+
+  public String getPrimaryLanguage() {
+    return primaryLanguage;
+  }
+
+  public int getNumMentors() {
+    return numMentors;
+  }
+
+  public GHRepository getRepository() {
+    return repository;
+  }
+}

--- a/src/main/java/com/google/opensesame/projects/ProjectPreview.java
+++ b/src/main/java/com/google/opensesame/projects/ProjectPreview.java
@@ -28,8 +28,9 @@ public class ProjectPreview {
    * Creates a ProjectPreview object from a set of project properties and it's associated GitHub
    * repository.
    *
-   * @param properties The properties of a project. This will most likely come from a datastore
-   *     entity.
+   * @param properties The properties of a project entity. This can come directly from a datastore
+   *     entity, as datastore entities inherit a getProperty() method from PropertyContainer:
+   *     https://cloud.google.com/appengine/docs/standard/java/javadoc/com/google/appengine/api/datastore/Entity
    * @param repository The GitHub repository associated with the project.
    * @return Returns the created ProjectPreview
    * @throws IOException Throws when there is an error communicating with the GitHub API.

--- a/src/main/java/com/google/opensesame/servlets/ProjectPreviewsServlet.java
+++ b/src/main/java/com/google/opensesame/servlets/ProjectPreviewsServlet.java
@@ -18,15 +18,15 @@ public class ProjectPreviewsServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     ArrayList<Entity> testProjectEntities = new ArrayList<Entity>();
-    Entity testProjectEntity = new Entity("Project");
-    testProjectEntity.setProperty("repositoryName", "tensorflow/tensorflow");
-    testProjectEntity.setProperty("numMentors", 5);
-    testProjectEntities.add(testProjectEntity);
+    Entity firstTestProjectEntity = new Entity("Project");
+    firstTestProjectEntity.setProperty("repositoryName", "tensorflow/tensorflow");
+    firstTestProjectEntity.setProperty("numMentors", 5);
+    testProjectEntities.add(firstTestProjectEntity);
 
-    testProjectEntity = new Entity("Project");
-    testProjectEntity.setProperty("repositoryName", "kubernetes/kubernetes");
-    testProjectEntity.setProperty("numMentors", 1);
-    testProjectEntities.add(testProjectEntity);
+    Entity secondTestProjectEntity = new Entity("Project");
+    secondTestProjectEntity.setProperty("repositoryName", "kubernetes/kubernetes");
+    secondTestProjectEntity.setProperty("numMentors", 1);
+    testProjectEntities.add(secondTestProjectEntity);
 
     ArrayList<ProjectPreview> projectPreviews = new ArrayList<ProjectPreview>();
     for (Entity projectEntity : testProjectEntities) {

--- a/src/main/java/com/google/opensesame/servlets/ProjectPreviewsServlet.java
+++ b/src/main/java/com/google/opensesame/servlets/ProjectPreviewsServlet.java
@@ -1,0 +1,41 @@
+package com.google.opensesame.servlets;
+
+import com.google.appengine.api.datastore.Entity;
+import com.google.gson.Gson;
+import com.google.opensesame.projects.ProjectPreview;
+import java.io.IOException;
+import java.util.ArrayList;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/project-previews")
+public class ProjectPreviewsServlet extends HttpServlet {
+
+  private final Gson gson = new Gson();
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    ArrayList<Entity> testProjectEntities = new ArrayList<Entity>();
+    Entity testProjectEntity = new Entity("Project");
+    testProjectEntity.setProperty("repositoryName", "tensorflow/tensorflow");
+    testProjectEntity.setProperty("numMentors", 5);
+    testProjectEntities.add(testProjectEntity);
+
+    testProjectEntity = new Entity("Project");
+    testProjectEntity.setProperty("repositoryName", "kubernetes/kubernetes");
+    testProjectEntity.setProperty("numMentors", 1);
+    testProjectEntities.add(testProjectEntity);
+
+    ArrayList<ProjectPreview> projectPreviews = new ArrayList<ProjectPreview>();
+    for (Entity projectEntity : testProjectEntities) {
+      projectPreviews.add(ProjectPreview.fromProperties(projectEntity.getProperties()));
+    }
+
+    String projectPreviewsJson = gson.toJson(projectPreviews);
+    response.setStatus(HttpServletResponse.SC_OK);
+    response.setContentType("application/json;");
+    response.getWriter().println(projectPreviewsJson);
+  }
+}

--- a/src/test/java/com/google/opensesame/projects/ProjectPreviewTest.java
+++ b/src/test/java/com/google/opensesame/projects/ProjectPreviewTest.java
@@ -1,0 +1,61 @@
+package com.google.opensesame.projects;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.kohsuke.github.GHRepository;
+import org.mockito.Mockito;
+
+@RunWith(JUnit4.class)
+public class ProjectPreviewTest {
+  private static Map<String, Object> projectProperties;
+  private static GHRepository mockRepository;
+
+  private static final String MOCK_REPO_NAME = "Hello-World";
+  private static final String MOCK_REPO_DESCRIPTION = "This is a test description.";
+  private static final List<String> MOCK_REPO_TOPICS =
+      Arrays.asList(new String[] {"tutorial", "examples"});
+  private static final String MOCK_REPO_PRIMARY_LANGUAGE = "javascript";
+  private static final int MOCK_PROJECT_NUM_MENTORS = 5;
+
+  @BeforeClass
+  public static void setUp() throws IOException {
+    mockRepository = Mockito.mock(GHRepository.class);
+    Mockito.when(mockRepository.getName()).thenReturn(MOCK_REPO_NAME);
+    Mockito.when(mockRepository.getDescription()).thenReturn(MOCK_REPO_DESCRIPTION);
+    Mockito.when(mockRepository.listTopics()).thenReturn(MOCK_REPO_TOPICS);
+    Mockito.when(mockRepository.getLanguage()).thenReturn(MOCK_REPO_PRIMARY_LANGUAGE);
+
+    projectProperties = new HashMap<String, Object>();
+    projectProperties.put("numMentors", MOCK_PROJECT_NUM_MENTORS);
+  }
+
+  @Test
+  public void populatesRepositoryInfo() throws IOException {
+    // Ensures that the project preview data is properly populated from the GitHub repository and
+    // datastore entity properties.
+    ProjectPreview projectPreview =
+        ProjectPreview.fromPropertiesAndRepository(projectProperties, mockRepository);
+
+    Assert.assertEquals(MOCK_REPO_NAME, projectPreview.getName());
+    Assert.assertEquals(MOCK_REPO_DESCRIPTION, projectPreview.getDescription());
+    Assert.assertEquals(MOCK_PROJECT_NUM_MENTORS, projectPreview.getNumMentors());
+    Assert.assertEquals(MOCK_REPO_PRIMARY_LANGUAGE, projectPreview.getPrimaryLanguage());
+
+    for (String repoTopic : MOCK_REPO_TOPICS) {
+      Assert.assertTrue(
+          projectPreview.getTopicTags().stream()
+              .anyMatch(
+                  (tag) -> {
+                    return tag.equals(repoTopic);
+                  }));
+    }
+  }
+}


### PR DESCRIPTION
* Adds the `ProjectPreview` class, which is intended to be serialized and sent in an API response. This object is constructed with a map of properties, which can be taken from a datastore entity.
  * *For now, the servlet returns the preview data from a mock datastore entity, but datastore support for project entities will be added soon.*
* Adds the `ProjectTag` object. For now the tag is just a string, but it is intended in the future to have tags of different types, which are indicated with colored tags.
* Adds a basic servlet for getting project previews. This servlet is intended to be separate from the servlet to get full project data to save on bandwidth and GitHub API requests.
  * The intention is to add more functionality to this get request in the future, including pagination and ID-based queries.