### PR TITLE
Add React authorization button to navbar

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -7,7 +7,7 @@
 <div id="navbar-container"></div>
 <h1 class="display-1 mb-5 mt-5">The Open Source Community is for <span class="emphasis">Everyone</span></h1>
 <spacer class="space"></spacer>
-<button class="btn mt-5 text-center"><span class="display-4">Mentorship Awaits</span></button>
+<button class="btn btn-shadow mt-5 text-center w-75"><span class="display-4">Mentorship Awaits</span></button>
 
 <!-- Load React. -->
 <!-- Note: when deploying, replace "development.js" with "production.min.js". -->

--- a/src/main/webapp/js/common/react/components/AuthButton.js
+++ b/src/main/webapp/js/common/react/components/AuthButton.js
@@ -10,7 +10,7 @@ checkTesting();
 export default class AuthButton extends React.Component {
   /**
    * Create the AuthButton react component.
-   * @param {{}} props 
+   * @param {{}} props
    */
   constructor(props) {
     super(props);
@@ -55,7 +55,7 @@ export default class AuthButton extends React.Component {
    * @return {React.Component}
    * @override
    */
-  render() { 
+  render() {
     let classList = 'btn btn-primary';
     if (this.state.isFetching) {
       // The button is disabled while the authorization data is being loaded.

--- a/src/main/webapp/js/common/react/components/AuthButton.js
+++ b/src/main/webapp/js/common/react/components/AuthButton.js
@@ -25,7 +25,7 @@ export default class AuthButton extends React.Component {
    * @override
    */
   componentDidMount() {
-     const fetchRequest = standardizeFetchErrors(fetch('/auth'),
+    const fetchRequest = standardizeFetchErrors(fetch('/auth'),
         'Failed to communicate with the server, please try again later.',
         'Encountered a server error, please try again later.');
 

--- a/src/main/webapp/js/common/react/components/AuthButton.js
+++ b/src/main/webapp/js/common/react/components/AuthButton.js
@@ -25,14 +25,7 @@ export default class AuthButton extends React.Component {
    * @override
    */
   componentDidMount() {
-    this.fetchAuthorizationStatus();
-  }
-
-  /**
-   * Fetches the authorization status of the user and updates the button.
-   */
-  fetchAuthorizationStatus() {
-    const fetchRequest = standardizeFetchErrors(fetch('/auth'),
+     const fetchRequest = standardizeFetchErrors(fetch('/auth'),
         'Failed to communicate with the server, please try again later.',
         'Encountered a server error, please try again later.');
 

--- a/src/main/webapp/js/common/react/components/AuthButton.js
+++ b/src/main/webapp/js/common/react/components/AuthButton.js
@@ -22,6 +22,7 @@ export default class AuthButton extends React.Component {
 
   /**
    * Loads user authorization data after React has initialized the component.
+   * @override
    */
   componentDidMount() {
     this.fetchAuthorizationStatus();
@@ -52,6 +53,7 @@ export default class AuthButton extends React.Component {
    * Renders the Login/Logout button. If the authorization data is still
    * loading, the button is disabled.
    * @return {React.Component}
+   * @override
    */
   render() { 
     let classList = 'btn btn-primary';

--- a/src/main/webapp/js/common/react/components/AuthButton.js
+++ b/src/main/webapp/js/common/react/components/AuthButton.js
@@ -1,0 +1,81 @@
+import checkTesting from '../../../checkTesting.js';
+import standardizeFetchErrors from '../../../fetch_handler.js';
+checkTesting();
+
+/**
+ * Login/Logout button that fetches user authorization data to automatically
+ * update its appearance.
+ * @extends React.Component
+ */
+export default class AuthButton extends React.Component {
+  /**
+   * Create the AuthButton react component.
+   * @param {{}} props 
+   */
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isFetching: true,
+    };
+  }
+
+  /**
+   * Loads user authorization data after React has initialized the component.
+   */
+  componentDidMount() {
+    this.fetchAuthorizationStatus();
+  }
+
+  /**
+   * Fetches the authorization status of the user and updates the button.
+   */
+  fetchAuthorizationStatus() {
+    const fetchRequest = standardizeFetchErrors(fetch('/auth'),
+        'Failed to communicate with the server, please try again later.',
+        'Encountered a server error, please try again later.');
+
+    fetchRequest.then((authData) => {
+      console.log('Auth data received:');
+      console.log(authData);
+      this.setState({
+        isFetching: false,
+        authData,
+      });
+    }).catch((errorResponse) => {
+      console.error(
+          `Error ${errorResponse.statusCode}: ${errorResponse.error}`);
+    });
+  }
+
+  /**
+   * Renders the Login/Logout button. If the authorization data is still
+   * loading, the button is disabled.
+   * @return {React.Component}
+   */
+  render() { 
+    let classList = 'btn btn-primary';
+    if (this.state.isFetching) {
+      // The button is disabled while the authorization data is being loaded.
+      classList += ' disabled';
+    }
+
+    let linkText = 'Log In';
+    let authLink = '/';
+    console.log(this.state);
+    if (!this.state.isFetching) {
+      if (this.state.authData.authorized) {
+        authLink = this.state.authData.logoutUrl;
+        linkText = 'Log Out';
+      } else {
+        authLink = this.state.authData.loginUrl;
+      }
+    }
+
+    return (
+      <a href={authLink} className={classList}>
+        {linkText}
+      </a>
+    );
+  }
+}

--- a/src/main/webapp/js/common/react/components/Navbar.js
+++ b/src/main/webapp/js/common/react/components/Navbar.js
@@ -1,5 +1,6 @@
 import checkTesting from '../../../checkTesting.js';
 import NavbarLink from './NavbarLink.js';
+import AuthButton from './AuthButton.js';
 checkTesting();
 
 /**
@@ -30,6 +31,9 @@ export default function Navbar(props) {
           {props.urls.map((url, i) =>
               <NavbarLink key={i} href={url.href} name={url.name} />)}
         </ul>
+      </div>
+      <div className="ml-1">
+        <AuthButton />
       </div>
     </nav>
   );

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -11,10 +11,25 @@ a:hover,
 
 .btn {
   background-color: rebeccapurple;
-  border-radius: 8px;
   border: none;
+  border-radius: 8px;
   color: white;
-  width: 70%;
+}
+
+.btn:hover {
+  background-color: purple;
+  border: none;
+  border-radius: 8px;
+  color: white;
+}
+
+.btn.disabled {
+  background-color: rebeccapurple;
+  color: white;
+}
+
+.btn-shadow:hover {
+  box-shadow: 0 12px 16px 0 rgba(0, 0, 0, 0.24), 0 17px 50px 0 rgba(0, 0, 0, 0.19);
 }
 
 .card-holder {
@@ -23,10 +38,5 @@ a:hover,
 
 .card-holder:hover {
   box-shadow: 0 12px 16px 0 rgba(0,0,0,0.24),0 17px 50px 0 rgba(0,0,0,0.19);
-}
-
-.btn:hover {
-  background-color: purple;
-  box-shadow: 0 12px 16px 0 rgba(0, 0, 0, 0.24), 0 17px 50px 0 rgba(0, 0, 0, 0.19);
 }
 


### PR DESCRIPTION
* Add a React-based authorization button that fetches authorization data from the authorization servlet and updates its appearance to either be a "Log In" button or a "Log Out" button.
* Add this authorization button to the navbar for easy website-wide access.
* Update the main style sheet `style.css` to be more permitting of other buttons other than those on the main home page.

The intended flow is for a new user to sign up with this button, from which they are redirected (by the login page) to their profile, where they can set data about themselves and link their GitHub accounts.