### PR TITLE
Change authorization into an object model

### DIFF
--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -18,6 +18,7 @@ const firebaseConfig = {
  * NOTE: The authorization.js file location might change.
  */
 class GitHubAuthorizer {
+
   /**
    * Create a GitHubAuthorizer.
    */
@@ -27,13 +28,13 @@ class GitHubAuthorizer {
     this.token = null;
 
     /**
-     * the Firebase instance associated with a given 
+     * the Firebase instance associated with a given
      * GitHubAuthorizer
      * @type {Firebase}
      */
     this.firebase = firebase; // eslint-disable-line
 
-    this.initializeFirebase()
+    this.initializeFirebase();
   }
 
   /**
@@ -108,7 +109,7 @@ class GitHubAuthorizer {
       this.getFirebase().auth().signOut();
       this.token = null;
     }
-    return true
+    return true;
   }
 
   /**

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -105,7 +105,6 @@ class GitHubAuthorizer {
    *
    * @return {<Promise> null} can throw errors
    */
-
   async signOut() {
     return this.getFirebase().auth().signOut().then(() => {
       this.token = null;

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -20,7 +20,7 @@ const firebaseConfig = {
 class GithubAuthorizer {
   constructor() { // eslint-disable-line
     GithubAuthorizer.initializeFirebase();
-    this.token = '';
+    this.token = null;
     this.firebase = firebase; // eslint-disable-line
   }
 

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -7,9 +7,15 @@ const firebaseConfig = {
 /**
  * Object used for Github authorization and as a wrapper for firebase.
  * It handles Firebase initialization on instantiation and holds nifty
- * functions for handling github authorization
+ * functions for handling github authorization. We are using a class to have
+ * access tokens persist for ease opf use on the backend
  * 
- * make sure to include this script when using
+ * Make sure to include the scripts below in any HTML File that uses this class
+ * 
+ * <script src="https://www.gstatic.com/firebasejs/7.15.5/firebase.js"></script>
+ * <script type="module" src="authorization.js"></script>
+ * 
+ * NOTE: The authorization.js file location mighjt change.
  */
 class GithubAuthorizer {
   constructor() {
@@ -22,15 +28,20 @@ class GithubAuthorizer {
    * The most recent access token for the Github API. To refresh this, the user
    * must be signed out and signed in again. It is important to keep in mind
    * that this token expires and must be used swiftly after calling
-   * toggleSignIn(). If sign is yet to be toggled, this will return an empty
-   * string
+   * toggleSignIn(). If authorization is yet to be toggled, this will return 
+   * null. If an error occurs during authorization, it will again be set to
+   * null. This property will be set to null on sign out as well.
+   * 
+   * NOTE: In the event that an access token times out, the token will still be
+   * available here and so, a non-null token is not a good sign of a valid
+   * token. 
    */
   get token() {
     this.token;
   }
 
   /**
-   * the current user if signed in and null if not. For all intents and
+   * the current user if authorized and null if not. For all intents and
    * purposes, this function will serve as a true/false value in an if
    * statement.
    */
@@ -64,7 +75,7 @@ class GithubAuthorizer {
    * Side Effects: when authorizing a user, it sets the current objects token
    * to the returned Github API accessToken if a token is returned.
    */
-  toggleSignIn() {
+  toggleAuthorization() {
     firebase = this.firebase;
     if (!firebase.auth().currentUser) {
       let provider = new firebase.auth.GithubAuthProvider();
@@ -72,8 +83,10 @@ class GithubAuthorizer {
         // This gives you a GitHub Access Token.
         // You can use it to access the GitHub API.
         this.token = result.credential.accessToken;
+        console.log(token);
       }).catch(function(error) {
-        // Handle Errors here.
+        this.token = null
+          // Handle Errors here.
         console.error(error);
         // TODO: Change this in future iterations
         alert(error.message);
@@ -81,7 +94,7 @@ class GithubAuthorizer {
     } else {
       // if logged in, sign out
       firebase.auth().signOut();
-
+      this.token = null;
     }
   }
 
@@ -90,7 +103,7 @@ class GithubAuthorizer {
    * purposes, this function will serve as a true/false value in an if
    * statement.
    */
-  isSignedIn() {
+  isAuthorized() {
     return this.firebase.auth().currentUser;
   }
 }

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -105,7 +105,7 @@ class GitHubAuthorizer {
    *
    * @return {<Promise> null} can throw errors
    */
-  async signOut() {
+  signOut() {
     return this.getFirebase().auth().signOut().then(() => {
       this.token = null;
       return null;

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -88,10 +88,11 @@ class GitHubAuthorizer {
    */
   async signIn() {
     let provider = new this.firebase.auth.GithubAuthProvider();
-    let gitHubProviderResults =
-      await this.getFirebase().auth().signInWithPopup(provider);
-    this.token = gitHubProviderResults.credential.accessToken;
-    return gitHubProviderResults;
+    return this.getFirebase().auth().signInWithPopup(provider)
+      .then((result) => {
+        this.token = result.credential.accessToken;
+        return result;
+      });
   }
 
   /**
@@ -106,9 +107,10 @@ class GitHubAuthorizer {
    */
 
   async signOut() {
-    await this.getFirebase().auth().signOut();
-    this.token = null;
-    return null;
+    return this.getFirebase().auth().signOut().then(() => {
+      this.token = null;
+      return null;
+    });
   }
 
   /**

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -6,10 +6,10 @@ const firebaseConfig = {
 
 /**
  * The enum returned after authorization is toggled
- * @typedef AuthorizationEnum 
+ * @typedef AuthorizationEnum
  * @property {boolean} isValid false if an error occurs during authorization
  * true otherwise.
- * @property {String} gitHubToken a GitHub API access token if user was 
+ * @property {String} gitHubToken a GitHub API access token if user was
  * authorized null otherwise
  */
 
@@ -27,7 +27,6 @@ const firebaseConfig = {
  * NOTE: The authorization.js file location might change.
  */
 class GitHubAuthorizer {
-
   /**
    * Create a GitHubAuthorizer.
    */

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -8,7 +8,7 @@ const firebaseConfig = {
  * Object used for Github authorization and as a wrapper for firebase.
  * It handles Firebase initialization on instantiation and holds nifty
  * functions for handling github authorization. We are using a class to have
- * access tokens persist for ease opf use on the backend
+ * access tokens persist for ease of use on the backend
  *
  * Make sure to include the scripts below in any HTML File that uses this class
  *

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -1,3 +1,5 @@
+importScripts("https://www.gstatic.com/firebasejs/7.15.5/firebase-auth.js")
+
 // GCP Generated Github OAuth configuration
 const config = {
   apiKey: 'AIzaSyAR88Giah8cCEAvT_zDSIREWvgIIAeS8yY',
@@ -9,15 +11,26 @@ const config = {
  * be called as many times as we need without any side effects.
  */
 function initializeFirebase() {
+  firebase = getFirebase();
   if (firebase.apps.length === 0) {
     firebase.initializeApp(config);
   }
 }
 
 /**
+ * Get firebase
+ * @return {Firebase}
+ */
+function getFirebase() {
+  return firebase; //eslint-disable-line
+}
+
+
+/**
  * Function called when clicking the Login/Logout button.
  */
 function toggleSignIn() {
+  firebase = getFirebase();
   if (!firebase.auth().currentUser) {
     let provider = new firebase.auth.GithubAuthProvider();
     firebase.auth().signInWithPopup(provider).then(function(result) {
@@ -41,4 +54,5 @@ function toggleSignIn() {
 export {
   initializeFirebase,
   toggleSignIn,
+  getFirebase,
 };

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -1,5 +1,3 @@
-importScripts("https://www.gstatic.com/firebasejs/7.15.5/firebase-auth.js")
-
 // GCP Generated Github OAuth configuration
 const config = {
   apiKey: 'AIzaSyAR88Giah8cCEAvT_zDSIREWvgIIAeS8yY',
@@ -7,52 +5,92 @@ const config = {
 };
 
 /**
- * Initialize firebase if firebase is not already initialized. This method can
- * be called as many times as we need without any side effects.
+ * Object used for Github authorization and as a wrapper for firebase.
+ * It handles Firebase initialization on instantiation and holds nifty
+ * functions for handling github authorization
  */
-function initializeFirebase() {
-  firebase = getFirebase();
-  if (firebase.apps.length === 0) {
-    firebase.initializeApp(config);
+class GithubAuthorizer {
+  constructor() {
+    initializeFirebase();
+    this.token = "";
+    this.firebase = firebase;
+  }
+
+  /**
+   * The most recent access token for the Github API. To refresh this, the user
+   * must be signed out and signed in again. It is important to keep in mind
+   * that this token expires and must be used swiftly after calling
+   * toggleSignIn(). If sign is yet to be toggled, this will return an empty
+   * string
+   */
+  get token() {
+    this.token;
+  }
+
+  /**
+   * the current user if signed in and null if not. For all intents and
+   * purposes, this function will serve as a true/false value in an if
+   * statement.
+   */
+  get user() {
+    firebase.auth().currentUser;;
+  }
+
+  /**
+   * Initialize firebase if firebase is not already initialized. This method can
+   * be called as many times as we need without any side effects.
+   */
+  initializeFirebase() {
+    if (firebase.apps.length === 0) { // eslint-disable-line
+      firebase.initializeApp(config); // eslint-disable-line
+    }
+  }
+
+  /**
+   * Get firebase instance used with this object
+   */
+  get firebase() {
+    return firebase; // eslint-disable-line
+  }
+
+
+  /**
+   * Function called when authorizing user to verify them as a github user.
+   * This function doubles as an opt out when the current user wants to leave
+   * our site for good.
+   * 
+   * Side Effects: when authorizing a user, it sets the current objects token
+   * to the returned Github API accessToken if a token is returned.
+   */
+  toggleSignIn() {
+    firebase = getFirebase();
+    if (!firebase.auth().currentUser) {
+      let provider = new firebase.auth.GithubAuthProvider();
+      firebase.auth().signInWithPopup(provider).then(function(result) {
+        // This gives you a GitHub Access Token.
+        // You can use it to access the GitHub API.
+        this.token = result.credential.accessToken;
+      }).catch(function(error) {
+        // Handle Errors here.
+        console.error(error);
+        // TODO: Change this in future iterations
+        alert(error.message);
+      });
+    } else {
+      // if logged in, sign out
+      firebase.auth().signOut();
+
+    }
+  }
+
+  /**
+   * Returns the current user if signed in and null if not. For all intents and
+   * purposes, this function will serve as a true/false value in an if
+   * statement.
+   */
+  isSignedIn() {
+    return firebase.auth().currentUser;
   }
 }
 
-/**
- * Get firebase
- * @return {Firebase}
- */
-function getFirebase() {
-  return firebase; //eslint-disable-line
-}
-
-
-/**
- * Function called when clicking the Login/Logout button.
- */
-function toggleSignIn() {
-  firebase = getFirebase();
-  if (!firebase.auth().currentUser) {
-    let provider = new firebase.auth.GithubAuthProvider();
-    firebase.auth().signInWithPopup(provider).then(function(result) {
-      // This gives you a GitHub Access Token.
-      // You can use it to access the GitHub API.
-      const token = result.credential.accessToken;
-      // The signed-in user info.
-      const user = result.user;
-    }).catch(function(error) {
-      // Handle Errors here.
-      console.error(error);
-      // Change this in future iterations
-      alert(error.message);
-    });
-  } else {
-    // if logged in, sign out
-    firebase.auth().signOut();
-  }
-}
-
-export {
-  initializeFirebase,
-  toggleSignIn,
-  getFirebase,
-};
+export default new GithubAuthorizer();

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -17,10 +17,18 @@ const firebaseConfig = {
  *
  * NOTE: The authorization.js file location might change.
  */
-class GithubAuthorizer {
+class GitHubAuthorizer {
   constructor() { // eslint-disable-line
-    GithubAuthorizer.initializeFirebase();
+    GitHubAuthorizer.initializeFirebase();
+
+    /** @type {string} github API token */
     this.token = null;
+
+    /**
+     * the firbase instance associated with a given 
+     * GitHubAuthorizer
+     * @type {Firebase} 
+     */
     this.firebase = firebase; // eslint-disable-line
   }
 
@@ -78,7 +86,7 @@ class GithubAuthorizer {
     const firebase = this.firebase;
     if (!firebase.auth().currentUser) {
       try {
-        let provider = new firebase.auth.GithubAuthProvider();
+        let provider = new firebase.auth.GitHubAuthProvider();
         let authorizationResults =
           await firebase.auth().signInWithPopup(provider);
         // This gives you a GitHub Access Token.
@@ -112,4 +120,4 @@ class GithubAuthorizer {
   }
 }
 
-export let githubAuthorizer = new GithubAuthorizer();
+export let gitHubAuthorizer = new GitHubAuthorizer();

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -81,14 +81,14 @@ class GitHubAuthorizer {
    *
    * NOTE: this function is asynchronous and should be used with an await
    *
-   * @return {<Promise> Firebase.UserCredential} credentials of the 
+   * @return {Promise <Firebase.UserCredential>} credentials of the 
    * authorized user. Can throw errors.
    */
   async signIn() {
     let provider = new this.firebase.auth.GithubAuthProvider();
     let gitHubProviderResults =
-      await this.getFirebase().auth().signInWithPopup(provider);
-    this.token = await authorizationResults.credential.accessToken;
+      this.getFirebase().auth().signInWithPopup(provider);
+    this.token = await gitHubProviderResults.credential.accessToken;
     return gitHubProviderResults;
   }
 

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -68,7 +68,7 @@ class GithubAuthorizer {
    *
    * Side Effects: when authorizing a user, it sets the current objects token
    * to the returned Github API accessToken if a token is returned.
-   * 
+   *
    * NOTE: this function is asynchronous and should be used with an await
    *
    * @return {string} the GitHub API access token, null if an error occurs or

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -1,5 +1,5 @@
 // GCP Generated Github OAuth configuration
-const config = {
+const firebaseConfig = {
   apiKey: 'AIzaSyAR88Giah8cCEAvT_zDSIREWvgIIAeS8yY',
   authDomain: 'step2020-279820.firebaseapp.com',
 };
@@ -8,12 +8,14 @@ const config = {
  * Object used for Github authorization and as a wrapper for firebase.
  * It handles Firebase initialization on instantiation and holds nifty
  * functions for handling github authorization
+ * 
+ * make sure to include this script when using
  */
 class GithubAuthorizer {
   constructor() {
     initializeFirebase();
     this.token = "";
-    this.firebase = firebase;
+    this.firebase = firebase; // eslint-disable-line
   }
 
   /**
@@ -33,7 +35,7 @@ class GithubAuthorizer {
    * statement.
    */
   get user() {
-    firebase.auth().currentUser;;
+    this.firebase.auth().currentUser;;
   }
 
   /**
@@ -42,7 +44,7 @@ class GithubAuthorizer {
    */
   initializeFirebase() {
     if (firebase.apps.length === 0) { // eslint-disable-line
-      firebase.initializeApp(config); // eslint-disable-line
+      firebase.initializeApp(firebaseConfig); // eslint-disable-line
     }
   }
 
@@ -50,7 +52,7 @@ class GithubAuthorizer {
    * Get firebase instance used with this object
    */
   get firebase() {
-    return firebase; // eslint-disable-line
+    this.firebase;
   }
 
 
@@ -63,7 +65,7 @@ class GithubAuthorizer {
    * to the returned Github API accessToken if a token is returned.
    */
   toggleSignIn() {
-    firebase = getFirebase();
+    firebase = this.firebase;
     if (!firebase.auth().currentUser) {
       let provider = new firebase.auth.GithubAuthProvider();
       firebase.auth().signInWithPopup(provider).then(function(result) {
@@ -89,7 +91,7 @@ class GithubAuthorizer {
    * statement.
    */
   isSignedIn() {
-    return firebase.auth().currentUser;
+    return this.firebase.auth().currentUser;
   }
 }
 

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -72,7 +72,7 @@ class GithubAuthorizer {
    * NOTE: this function is asynchronous and should be used with an await
    *
    * @return {string} the GitHub API access token, null if an error occurs or
-   * the given user is no longer athorized.
+   * the given user is no longer authorized.
    */
   async toggleAuthorization() {
     const firebase = this.firebase;

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -5,6 +5,15 @@ const firebaseConfig = {
 };
 
 /**
+ * The enum returned after authorization is toggled
+ * @typedef AuthorizationEnum 
+ * @property {boolean} isValid false if an error occurs during authorization
+ * true otherwise.
+ * @property {String} gitHubToken a GitHub API access token if user was 
+ * authorized null otherwise
+ */
+
+/**
  * Object used for GitHub authorization and as a wrapper for Firebase.
  * It handles Firebase initialization on instantiation and holds nifty
  * functions for handling GitHub authorization. We are using a class to have
@@ -84,8 +93,8 @@ class GitHubAuthorizer {
    *
    * NOTE: this function is asynchronous and should be used with an await
    *
-   * @return {boolean} true if no errors occured during authorization, false
-   * otherwise
+   * @return {AuthorizationEnum} true if no errors occured during
+   * authorization, false otherwise.
    */
   async toggleAuthorization() {
     if (!this.getFirebase().auth().currentUser) {
@@ -102,14 +111,20 @@ class GitHubAuthorizer {
         // TODO: Change this in future iterations
         alert(error.message);
         this.token = null;
-        return false;
+        return {
+          gitHubToken: null,
+          isValid: false,
+        };
       }
     } else {
       // if logged in, sign out
       this.getFirebase().auth().signOut();
       this.token = null;
     }
-    return true;
+    return {
+      gitHubToken: this.token,
+      isValid: true,
+    };
   }
 
   /**
@@ -119,8 +134,8 @@ class GitHubAuthorizer {
    * NOTE: This is not an instance function and will not be exported.
    */
   initializeFirebase() {
-    if (this.getFirebase().apps.length === 0) { // eslint-disable-line
-      this.getFirebase().initializeApp(firebaseConfig); // eslint-disable-line
+    if (this.getFirebase().apps.length === 0) {
+      this.getFirebase().initializeApp(firebaseConfig);
     }
   }
 }

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -79,8 +79,8 @@ class GitHubAuthorizer {
    *
    * NOTE: this function is asynchronous and should be used with an await
    *
-   * @return {string} the GitHub API access token, null if an error occurs or
-   * the given user is no longer authorized.
+   * @return {boolean} true if no errors occured during authorization, false
+   * otherwise
    */
   async toggleAuthorization() {
     const firebase = this.firebase;
@@ -98,13 +98,14 @@ class GitHubAuthorizer {
         // TODO: Change this in future iterations
         alert(error.message);
         this.token = null;
+        return false
       }
     } else {
       // if logged in, sign out
       firebase.auth().signOut();
       this.token = null;
     }
-    return this.token;
+    return true
   }
 
   /**

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -43,7 +43,7 @@ class GithubAuthorizer {
   }
 
   /**
-   * the current user if authorized and null if not. For all intents and
+   * The current user if authorized and null if not. For all intents and
    * purposes, this function will serve as a true/false value in an if
    * statement.
    *

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -19,7 +19,6 @@ const firebaseConfig = {
  */
 class GitHubAuthorizer {
   constructor() { // eslint-disable-line
-    GitHubAuthorizer.initializeFirebase();
 
     /** @type {string} gitHub API token */
     this.token = null;
@@ -30,6 +29,8 @@ class GitHubAuthorizer {
      * @type {Firebase} 
      */
     this.firebase = firebase; // eslint-disable-line
+
+    this.initializeFirebase()
   }
 
   /**
@@ -83,12 +84,11 @@ class GitHubAuthorizer {
    * otherwise
    */
   async toggleAuthorization() {
-    const firebase = this.firebase;
-    if (!firebase.auth().currentUser) {
+    if (!this.getFirebase().auth().currentUser) {
       try {
-        let provider = new firebase.auth.GitHubAuthProvider();
+        let provider = new this.firebase.auth.GithubAuthProvider();
         let authorizationResults =
-          await firebase.auth().signInWithPopup(provider);
+          await this.getFirebase().auth().signInWithPopup(provider);
         // This gives you a GitHub Access Token.
         // You can use it to access the GitHub API.
         this.token = await authorizationResults.credential.accessToken;
@@ -102,7 +102,7 @@ class GitHubAuthorizer {
       }
     } else {
       // if logged in, sign out
-      firebase.auth().signOut();
+      this.getFirebase().auth().signOut();
       this.token = null;
     }
     return true
@@ -114,9 +114,9 @@ class GitHubAuthorizer {
    *
    * NOTE: This is not an instance function and will not be exported.
    */
-  static initializeFirebase() {
-    if (firebase.apps.length === 0) { // eslint-disable-line
-      firebase.initializeApp(firebaseConfig); // eslint-disable-line
+  initializeFirebase() {
+    if (this.getFirebase().apps.length === 0) { // eslint-disable-line
+      this.getFirebase().initializeApp(firebaseConfig); // eslint-disable-line
     }
   }
 }

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -83,7 +83,7 @@ class GitHubAuthorizer {
    *
    * NOTE: this function is asynchronous and should be used with an await
    *
-   * @return {Promise <Firebase.UserCredential>} credentials of the 
+   * @return {UserCredentia} credentials of the 
    * authorized user. Can throw errors.
    */
   async signIn() {

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -86,7 +86,7 @@ class GitHubAuthorizer {
    * @return {Firebase.UserCredential} credentials of the
    * authorized user. Can throw errors.
    */
-  async signIn() {
+  signIn() {
     let provider = new this.firebase.auth.GithubAuthProvider();
     return this.getFirebase().auth().signInWithPopup(provider)
       .then((result) => {

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -23,13 +23,13 @@ class GitHubAuthorizer {
    */
   constructor() {
     /**
-     * the firbase instance associated with a given 
+     * the firebase instance associated with a given
      * GitHubAuthorizer
-     * @type {Firebase} 
+     * @type {Firebase}
      */
     this.firebase = firebase; // eslint-disable-line
 
-    this.initializeFirebase()
+    this.initializeFirebase();
 
     /** @type {string} gitHub API token */
     this.token = null;
@@ -83,7 +83,7 @@ class GitHubAuthorizer {
    *
    * NOTE: this function is asynchronous and should be used with an await
    *
-   * @return {Firebase.UserCredential} credentials of the 
+   * @return {Firebase.UserCredential} credentials of the
    * authorized user. Can throw errors.
    */
   async signIn() {
@@ -123,7 +123,7 @@ class GitHubAuthorizer {
    *
    * NOTE: this function is asynchronous and should be used with an await
    *
-   * @return {<Promise> Firebase.UserCredential | null} credentials of the 
+   * @return {<Promise> Firebase.UserCredential | null} credentials of the
    * authorized user or null the user is signed out
    */
   toggleSignIn() {

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -81,24 +81,15 @@ class GitHubAuthorizer {
    *
    * NOTE: this function is asynchronous and should be used with an await
    *
-   * @return {<Promise> Firebase.UserCredential | null} credentials of the 
-   * authorized user or null if an error occurs
+   * @return {<Promise> Firebase.UserCredential} credentials of the 
+   * authorized user. Can throw errors.
    */
   async signIn() {
-    try {
-      let provider = new this.firebase.auth.GithubAuthProvider();
-      let gitHubProviderResults =
-        await this.getFirebase().auth().signInWithPopup(provider);
-      this.token = await authorizationResults.credential.accessToken;
-      return gitHubProviderResults;
-    } catch (error) {
-      // Handle Errors here
-      console.error(error);
-      // TODO: Change this in future iterations	
-      alert(error.message);
-      this.token = null;
-      return null;
-    };
+    let provider = new this.firebase.auth.GithubAuthProvider();
+    let gitHubProviderResults =
+      await this.getFirebase().auth().signInWithPopup(provider);
+    this.token = await authorizationResults.credential.accessToken;
+    return gitHubProviderResults;
   }
 
   /**
@@ -109,19 +100,12 @@ class GitHubAuthorizer {
    *
    * NOTE: this function is asynchronous and should be used with an await
    *
-   * @return {<Promise> null} 
+   * @return {<Promise> null} can throw errors
    */
 
   async signOut() {
-    try {
-      await this.getFirebase().auth().signOut();
-      this.token = null;
-    } catch (error) {
-      // Handle Errors here
-      console.error(error);
-      // TODO: Change this in future iterations	
-      alert(error.message);
-    };
+    await this.getFirebase().auth().signOut();
+    this.token = null;
     return null;
   }
 
@@ -136,7 +120,7 @@ class GitHubAuthorizer {
    * NOTE: this function is asynchronous and should be used with an await
    *
    * @return {<Promise> Firebase.UserCredential | null} credentials of the 
-   * authorized user or null if an error occurs or the user is signed out
+   * authorized user or null the user is signed out
    */
   toggleSignIn() {
     if (this.getUser()) {

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -9,18 +9,19 @@ const firebaseConfig = {
  * It handles Firebase initialization on instantiation and holds nifty
  * functions for handling github authorization. We are using a class to have
  * access tokens persist for ease opf use on the backend
- * 
+ *
  * Make sure to include the scripts below in any HTML File that uses this class
  * 
  * <script src="https://www.gstatic.com/firebasejs/7.15.5/firebase.js"></script>
  * <script type="module" src="authorization.js"></script>
- * 
+ *
  * NOTE: The authorization.js file location mighjt change.
  */
 class GithubAuthorizer {
+  /** @return {GithubAuthorizer} */
   constructor() {
     initializeFirebase();
-    this.token = "";
+    this.token = '';
     this.firebase = firebase; // eslint-disable-line
   }
 
@@ -28,25 +29,29 @@ class GithubAuthorizer {
    * The most recent access token for the Github API. To refresh this, the user
    * must be signed out and signed in again. It is important to keep in mind
    * that this token expires and must be used swiftly after calling
-   * toggleSignIn(). If authorization is yet to be toggled, this will return 
+   * toggleSignIn(). If authorization is yet to be toggled, this will return
    * null. If an error occurs during authorization, it will again be set to
    * null. This property will be set to null on sign out as well.
-   * 
+   *
    * NOTE: In the event that an access token times out, the token will still be
    * available here and so, a non-null token is not a good sign of a valid
-   * token. 
+   * token.
+   *
+   * @return {string} most recent token or null
    */
   get token() {
-    this.token;
+    return this.token;
   }
 
   /**
    * the current user if authorized and null if not. For all intents and
    * purposes, this function will serve as a true/false value in an if
    * statement.
+   *
+   * @return {Firebase.User} current user or null
    */
   get user() {
-    this.firebase.auth().currentUser;;
+    return this.firebase.auth().currentUser;;
   }
 
   /**
@@ -61,9 +66,10 @@ class GithubAuthorizer {
 
   /**
    * Get firebase instance used with this object
+   * @return {Firebase} firebase instance
    */
   get firebase() {
-    this.firebase;
+    return this.firebase;
   }
 
 
@@ -99,4 +105,4 @@ class GithubAuthorizer {
   }
 }
 
-export default new GithubAuthorizer();
+export let githubAuthorizer = new GithubAuthorizer();

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -97,15 +97,6 @@ class GithubAuthorizer {
       this.token = null;
     }
   }
-
-  /**
-   * Returns the current user if signed in and null if not. For all intents and
-   * purposes, this function will serve as a true/false value in an if
-   * statement.
-   */
-  isAuthorized() {
-    return this.firebase.auth().currentUser;
-  }
 }
 
 export default new GithubAuthorizer();

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -5,12 +5,12 @@ const firebaseConfig = {
 };
 
 /**
- * Object used for GitHub authorization and as a wrapper for firebase.
+ * Object used for GitHub authorization and as a wrapper for Firebase.
  * It handles Firebase initialization on instantiation and holds nifty
- * functions for handling gitHub authorization. We are using a class to have
- * access tokens persist for ease of use on the backend
+ * functions for handling GitHub authorization. We are using a class to have
+ * access tokens persist for ease of use on the backend,
  *
- * Make sure to include the scripts below in any HTML File that uses this class
+ * Make sure to include the scripts below in any HTML file that uses this class.
  *
  * <script src="https://www.gstatic.com/firebasejs/7.15.5/firebase.js"></script>
  * <script type="module" src="authorization.js"></script>
@@ -18,15 +18,18 @@ const firebaseConfig = {
  * NOTE: The authorization.js file location might change.
  */
 class GitHubAuthorizer {
-  constructor() { // eslint-disable-line
+  /**
+   * Create a GitHubAuthorizer.
+   */
+  constructor() {
 
-    /** @type {string} gitHub API token */
+    /** @type {string} GitHub API token */
     this.token = null;
 
     /**
-     * the firbase instance associated with a given 
+     * the Firebase instance associated with a given 
      * GitHubAuthorizer
-     * @type {Firebase} 
+     * @type {Firebase}
      */
     this.firebase = firebase; // eslint-disable-line
 
@@ -59,7 +62,7 @@ class GitHubAuthorizer {
    * @return {Firebase.User} current user or null
    */
   getUser() {
-    return this.firebase.auth().currentUser;
+    return this.getFirebase().auth().currentUser;
   }
 
   /**
@@ -98,7 +101,7 @@ class GitHubAuthorizer {
         // TODO: Change this in future iterations
         alert(error.message);
         this.token = null;
-        return false
+        return false;
       }
     } else {
       // if logged in, sign out

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -95,35 +95,28 @@ class GitHubAuthorizer {
    * @return {AuthorizationEnum} true if no errors occured during
    * authorization, false otherwise.
    */
-  async toggleAuthorization() {
-    if (!this.getFirebase().auth().currentUser) {
-      try {
-        let provider = new this.firebase.auth.GithubAuthProvider();
-        let authorizationResults =
-          await this.getFirebase().auth().signInWithPopup(provider);
-        // This gives you a GitHub Access Token.
-        // You can use it to access the GitHub API.
-        this.token = await authorizationResults.credential.accessToken;
-      } catch (error) {
-        // Handle Errors here.
-        console.error(error);
-        // TODO: Change this in future iterations
-        alert(error.message);
-        this.token = null;
-        return {
-          gitHubToken: null,
-          isValid: false,
-        };
-      }
-    } else {
-      // if logged in, sign out
-      this.getFirebase().auth().signOut();
+  signIn() {
+    let provider = new this.firebase.auth.GithubAuthProvider();
+    return this.getFirebase().auth().signInWithPopup(provider)
+        .then((result) => {
+      this.token = result.credential.accessToken;
+      return result;
+    });
+  }
+
+  signOut() {
+    return this.getFirebase().auth().signOut().then(() => {
       this.token = null;
+      return null;
+    });
+  }
+
+  toggleSignIn() {
+    if (this.getUser()) {
+      return this.signOut();
+    } else {
+      return this.signIn();
     }
-    return {
-      gitHubToken: this.token,
-      isValid: true,
-    };
   }
 
   /**

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -83,7 +83,7 @@ class GitHubAuthorizer {
    *
    * NOTE: this function is asynchronous and should be used with an await
    *
-   * @return {UserCredentia} credentials of the 
+   * @return {Firebase.UserCredential} credentials of the 
    * authorized user. Can throw errors.
    */
   async signIn() {

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -11,16 +11,15 @@ const firebaseConfig = {
  * access tokens persist for ease opf use on the backend
  *
  * Make sure to include the scripts below in any HTML File that uses this class
- * 
+ *
  * <script src="https://www.gstatic.com/firebasejs/7.15.5/firebase.js"></script>
  * <script type="module" src="authorization.js"></script>
  *
  * NOTE: The authorization.js file location mighjt change.
  */
 class GithubAuthorizer {
-  /** @return {GithubAuthorizer} */
-  constructor() {
-    initializeFirebase();
+  constructor() { // eslint-disable-line
+    GithubAuthorizer.initializeFirebase();
     this.token = '';
     this.firebase = firebase; // eslint-disable-line
   }
@@ -51,17 +50,7 @@ class GithubAuthorizer {
    * @return {Firebase.User} current user or null
    */
   get user() {
-    return this.firebase.auth().currentUser;;
-  }
-
-  /**
-   * Initialize firebase if firebase is not already initialized. This method can
-   * be called as many times as we need without any side effects.
-   */
-  initializeFirebase() {
-    if (firebase.apps.length === 0) { // eslint-disable-line
-      firebase.initializeApp(firebaseConfig); // eslint-disable-line
-    }
+    return this.firebase.auth().currentUser;
   }
 
   /**
@@ -71,7 +60,6 @@ class GithubAuthorizer {
   get firebase() {
     return this.firebase;
   }
-
 
   /**
    * Function called when authorizing user to verify them as a github user.
@@ -101,6 +89,18 @@ class GithubAuthorizer {
       // if logged in, sign out
       firebase.auth().signOut();
       this.token = null;
+    }
+  }
+
+  /**
+   * Initialize firebase if firebase is not already initialized. This method can
+   * be called as many times as we need without any side effects.
+   *
+   * NOTE: This is not an instance function and will not be exported.
+   */
+  static initializeFirebase() {
+    if (firebase.apps.length === 0) { // eslint-disable-line
+      firebase.initializeApp(firebaseConfig); // eslint-disable-line
     }
   }
 }

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -5,11 +5,13 @@ const config = {
 };
 
 /**
- * Initialize firebase if firebase is not already initialized. This method can 
+ * Initialize firebase if firebase is not already initialized. This method can
  * be called as many times as we need without any side effects.
  */
 function initializeFirebase() {
-  if (firebase.apps.length === 0) { firebase.initializeApp(config); }
+  if (firebase.apps.length === 0) {
+    firebase.initializeApp(config);
+  }
 }
 
 /**
@@ -20,7 +22,7 @@ function toggleSignIn() {
   if (!firebase.auth().currentUser) {
     let provider = new firebase.auth.GithubAuthProvider();
     firebase.auth().signInWithPopup(provider).then(function(result) {
-      // This gives you a GitHub Access Token. 
+      // This gives you a GitHub Access Token.
       // You can use it to access the GitHub API.
       const token = result.credential.accessToken;
       // The signed-in user info.
@@ -37,4 +39,7 @@ function toggleSignIn() {
   }
 }
 
-export { initializeFirebase, toggleSignIn }
+export {
+  initializeFirebase,
+  toggleSignIn,
+};

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -1,13 +1,13 @@
-// GCP Generated Github OAuth configuration
+// GCP Generated GitHub OAuth configuration
 const firebaseConfig = {
   apiKey: 'AIzaSyAR88Giah8cCEAvT_zDSIREWvgIIAeS8yY',
   authDomain: 'step2020-279820.firebaseapp.com',
 };
 
 /**
- * Object used for Github authorization and as a wrapper for firebase.
+ * Object used for GitHub authorization and as a wrapper for firebase.
  * It handles Firebase initialization on instantiation and holds nifty
- * functions for handling github authorization. We are using a class to have
+ * functions for handling gitHub authorization. We are using a class to have
  * access tokens persist for ease of use on the backend
  *
  * Make sure to include the scripts below in any HTML File that uses this class
@@ -21,7 +21,7 @@ class GitHubAuthorizer {
   constructor() { // eslint-disable-line
     GitHubAuthorizer.initializeFirebase();
 
-    /** @type {string} github API token */
+    /** @type {string} gitHub API token */
     this.token = null;
 
     /**
@@ -33,7 +33,7 @@ class GitHubAuthorizer {
   }
 
   /**
-   * The most recent access token for the Github API. To refresh this, the user
+   * The most recent access token for the GitHub API. To refresh this, the user
    * must be signed out and signed in again. It is important to keep in mind
    * that this token expires and must be used swiftly after calling
    * toggleSignIn(). If authorization is yet to be toggled, this will return
@@ -70,12 +70,12 @@ class GitHubAuthorizer {
   }
 
   /**
-   * Function called when authorizing user to verify them as a github user.
+   * Function called when authorizing user to verify them as a gitHub user.
    * This function doubles as an opt out when the current user wants to leave
    * our site for good.
    *
    * Side Effects: when authorizing a user, it sets the current objects token
-   * to the returned Github API accessToken if a token is returned.
+   * to the returned GitHub API accessToken if a token is returned.
    *
    * NOTE: this function is asynchronous and should be used with an await
    *

--- a/src/main/webapp/authorization.js
+++ b/src/main/webapp/authorization.js
@@ -22,7 +22,7 @@ class GitHubAuthorizer {
    * Create a GitHubAuthorizer.
    */
   constructor() {
-   /**
+    /**
      * the firbase instance associated with a given 
      * GitHubAuthorizer
      * @type {Firebase} 
@@ -89,8 +89,8 @@ class GitHubAuthorizer {
   async signIn() {
     let provider = new this.firebase.auth.GithubAuthProvider();
     let gitHubProviderResults =
-      this.getFirebase().auth().signInWithPopup(provider);
-    this.token = await gitHubProviderResults.credential.accessToken;
+      await this.getFirebase().auth().signInWithPopup(provider);
+    this.token = gitHubProviderResults.credential.accessToken;
     return gitHubProviderResults;
   }
 

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -20,7 +20,3 @@
 <script src="https://unpkg.com/prop-types@15.6/prop-types.js"></script>
 <!-- Load React components -->
 <script type="module" src="./js-build/common/react/display_navbar.js"></script>
-
-<!-- Github OAuth -->
-<script src="https://www.gstatic.com/firebasejs/7.15.5/firebase.js"></script>
-<script type="module" src="authorization.js"></script>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -20,3 +20,7 @@
 <script src="https://unpkg.com/prop-types@15.6/prop-types.js"></script>
 <!-- Load React components -->
 <script type="module" src="./js-build/common/react/display_navbar.js"></script>
+
+<!-- Github OAuth -->
+<script src="https://www.gstatic.com/firebasejs/7.15.5/firebase.js"></script>
+<script type="module" src="authorization.js"></script>

--- a/src/test/java/com/google/opensesame/MentorTest.java
+++ b/src/test/java/com/google/opensesame/MentorTest.java
@@ -5,9 +5,9 @@ import com.google.opensesame.servlets.MentorObject;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Assert;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.junit.Test;
 
 @RunWith(JUnit4.class)
 public class MentorTest {

--- a/src/test/java/com/google/opensesame/MentorTest.java
+++ b/src/test/java/com/google/opensesame/MentorTest.java
@@ -1,11 +1,13 @@
-package com.google.opensesame.servlets;
+package com.google.opensesame;
 
+import com.google.opensesame.servlets.MentorBuilder;
+import com.google.opensesame.servlets.MentorObject;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Assert;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.junit.Test;
 
 @RunWith(JUnit4.class)
 public class MentorTest {


### PR DESCRIPTION
An object model will make it easier to keep track of fields such as the access token returned from GitHub. It seems like a good design decision and it works in the same way as the previous version of the Authorization module.
Reasons for this shift include;
- Removing the need to initialize ```firebase```.
- Creating an easy-to-use wrapper around ```firebase``` that does the basic functions we need and does not require any actual knowledge of ```firebase-auth``` from users of the module while exposing firebase if the need arises to use firebase features.
- Having persistent exposed variable.