### PR TITLE
Fix JS tests with fetch

### DIFF
--- a/src/main/webapp/js/checkTesting.js
+++ b/src/main/webapp/js/checkTesting.js
@@ -21,5 +21,6 @@ export default function checkTesting() {
   if ((typeof process !== 'undefined') && (process.release.name === 'node')) {
     global.PropTypes = require('prop-types');
     global.React = require('react');
+    global.fetch = require('fetch-mock-jest');
   }
 }

--- a/src/main/webapp/js/common/react/components/Navbar.js
+++ b/src/main/webapp/js/common/react/components/Navbar.js
@@ -1,6 +1,5 @@
 import checkTesting from '../../../checkTesting.js';
 import NavbarLink from './NavbarLink.js';
-import AuthButton from './AuthButton.js';
 checkTesting();
 
 /**
@@ -31,9 +30,6 @@ export default function Navbar(props) {
           {props.urls.map((url, i) =>
               <NavbarLink key={i} href={url.href} name={url.name} />)}
         </ul>
-      </div>
-      <div className="ml-1">
-        <AuthButton />
       </div>
     </nav>
   );

--- a/src/main/webapp/js/common/react/tests/Navbar.test.js
+++ b/src/main/webapp/js/common/react/tests/Navbar.test.js
@@ -2,6 +2,8 @@ import React from 'react';
 import Navbar from '../components/Navbar.js';
 import '@testing-library/jest-dom/extend-expect';
 import {render, screen} from '@testing-library/react';
+import fetchMock from 'fetch-mock-jest';
+import {makeRelativeUrlAbsolute} from '../../../fetch_handler.js';
 
 const navbarUrls = [
   {
@@ -13,6 +15,27 @@ const navbarUrls = [
     name: 'Projects',
   },
 ];
+
+beforeAll(() => {
+  const authData = {
+    authorized: false,
+    loginUrl: '/login',
+    logoutUrl: '/logout',
+    hasProfile: false,
+  };
+
+  fetchMock.get(makeRelativeUrlAbsolute('/auth'), {
+    body: JSON.stringify(authData),
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+});
+
+afterAll(() => {
+  fetchMock.restore();
+});
 
 describe('Navbar component', () => {
   it('is added to the DOM', () => {

--- a/src/main/webapp/js/fetch_handler.js
+++ b/src/main/webapp/js/fetch_handler.js
@@ -52,11 +52,11 @@ export function standardizeFetchErrors(
  * Makes a relative URL (like one to an Open Sesame endpoint) absolute. This
  * needs to be done for all fetch requests that are going to be tested with
  * NodeJS, as relative URLs are not supported on NodeJS.
- * @param {string} relativeUrl 
+ * @param {string} relativeUrl
  * @return {URL} Returns the absolute URL.
  */
 export function makeRelativeUrlAbsolute(relativeUrl) {
-  return new URL(relativeUrl, location.origin);
+  return new URL(relativeUrl, window.location.origin);
 }
 
 /**

--- a/src/main/webapp/js/fetch_handler.js
+++ b/src/main/webapp/js/fetch_handler.js
@@ -25,7 +25,7 @@
  * @return {Promise} Returns a promise that formats the errors from a fetch
  *    request.
  */
-export default function standardizeFetchErrors(
+export function standardizeFetchErrors(
     fetchRequest, fetchFailedUserMessage, genericServerErrorUserMessage) {
   return fetchRequest.catch((fetchError) => {
     // Fetch encountered an error while making the request (a network
@@ -46,6 +46,17 @@ export default function standardizeFetchErrors(
       return response.json();
     }
   });
+}
+
+/**
+ * Makes a relative URL (like one to an Open Sesame endpoint) absolute. This
+ * needs to be done for all fetch requests that are going to be tested with
+ * NodeJS, as relative URLs are not supported on NodeJS.
+ * @param {string} relativeUrl 
+ * @return {URL} Returns the absolute URL.
+ */
+export function makeRelativeUrlAbsolute(relativeUrl) {
+  return new URL(relativeUrl, location.origin);
 }
 
 /**

--- a/src/main/webapp/js/fetch_handler.test.js
+++ b/src/main/webapp/js/fetch_handler.test.js
@@ -1,5 +1,5 @@
 /* global fail */
-import standardizeFetchErrors from './fetch_handler.js';
+import {standardizeFetchErrors} from './fetch_handler.js';
 const fetchMock = require('fetch-mock-jest').sandbox();
 
 const fetchFailedMessage = 'Fetch failed';

--- a/src/main/webapp/js/projects/react/components/ProjectsSearch.js
+++ b/src/main/webapp/js/projects/react/components/ProjectsSearch.js
@@ -3,7 +3,10 @@
  * page. This handles the loading of project preview data.
  */
 import ProjectList from './ProjectList.js';
-import standardizeFetchErrors from '../../../fetch_handler.js';
+import {
+  standardizeFetchErrors,
+  makeRelativeUrlAbsolute
+} from '../../../fetch_handler.js';
 
 /**
  * The main project search page react component.
@@ -28,7 +31,7 @@ export default class ProjectsSearch extends React.Component {
    */
   componentDidMount() {
     const fetchRequest = standardizeFetchErrors(
-        fetch('/project-previews'),
+        fetch(makeRelativeUrlAbsolute('/project-previews')),
         'Failed to communicate with the server, please try again later.',
         'Encountered a server error, please try again later.');
     fetchRequest.then((projectPreviews) => {


### PR DESCRIPTION
This is a fix for JS tests that include fetch requests. 
* Because `fetch` is not defined outside of the browser environment, it must be manually defined with `fetch-mock-jest`. 
* Fetching from node requires absolute URLs, so added a utility function that converts relative URLs to absolute URLs in both browser and node.
* Adds mock authorization data to the navbar for use with the `/auth` endpoint. 
* For the time being, the AuthButton is removed from the navbar because it is being changed considerably for the frontend signup and adding testing support will come after the changes.