### PR TITLE
Add frontend signup functionality

### DIFF
--- a/src/main/java/com/google/opensesame/auth/AuthServlet.java
+++ b/src/main/java/com/google/opensesame/auth/AuthServlet.java
@@ -70,11 +70,9 @@ public class AuthServlet extends HttpServlet {
       // TODO : Add ability to check that a PersonObject exists in datastore with the user's ID.
       // For now, will assume to be false. This can be implemented when datastore support is added
       // for the PersonObject
-      // Checking the datastore for an existing PersonObject is mildly inefficient. This is a side
-      // effect of having to use the Users API on top of GitHub OAuth. Because there are two steps
-      // in signing up, this check ensures that the user has completed both authentication steps.
       // If in the future OAuth can be used for backend authentication (through something like the
-      // Firebase Auth Admin SDK), this check can be removed (along with all Users API code).
+      // Firebase Auth Admin SDK), we can remove the logic to check the datastore for an existing
+      // PersonObject with the user's ID (along with all Users API code).
       responseObject.addProperty("hasProfile", false);
     } else {
       responseObject.addProperty("authorized", false);

--- a/src/main/webapp/css/signup.css
+++ b/src/main/webapp/css/signup.css
@@ -1,42 +1,28 @@
-.emphasis,
-a {
-  color: rebeccapurple;
-  text-decoration: none;
-}
-
-a:hover,
-.dark-emph {
-  color: darkblue;
-}
-
-.btn {
+.btn-purple {
   background-color: rebeccapurple;
   border: none;
   border-radius: 8px;
   color: white;
 }
 
-.btn:hover {
+.btn-purple:hover {
   background-color: purple;
   border: none;
   border-radius: 8px;
   color: white;
 }
 
-.btn.disabled {
+.btn-purple.disabled {
   background-color: rebeccapurple;
   color: white;
 }
 
-.btn-shadow:hover {
+.btn-purple-shadow:hover {
   box-shadow: 0 12px 16px 0 rgba(0, 0, 0, 0.24), 0 17px 50px 0 rgba(0, 0, 0, 0.19);
 }
 
-.card-holder {
-  transition: .05s;
+.emphasis,
+a {
+  color: rebeccapurple;
+  text-decoration: none;
 }
-
-.card-holder:hover {
-  box-shadow: 0 12px 16px 0 rgba(0,0,0,0.24),0 17px 50px 0 rgba(0,0,0,0.19);
-}
-

--- a/src/main/webapp/js/common/react/components/AuthButton.js
+++ b/src/main/webapp/js/common/react/components/AuthButton.js
@@ -1,6 +1,11 @@
 import checkTesting from '../../../checkTesting.js';
-import standardizeFetchErrors from '../../../fetch_handler.js';
+import {
+  standardizeFetchErrors, 
+  makeRelativeUrlAbsolute
+} from '../../../fetch_handler.js';
 checkTesting();
+
+const USER_SIGNUP_URL = '/signup.html';
 
 /**
  * Login/Logout button that fetches user authorization data to automatically
@@ -25,7 +30,8 @@ export default class AuthButton extends React.Component {
    * @override
    */
   componentDidMount() {
-    const fetchRequest = standardizeFetchErrors(fetch('/auth'),
+    const fetchRequest = standardizeFetchErrors(
+        fetch(makeRelativeUrlAbsolute('/auth')),
         'Failed to communicate with the server, please try again later.',
         'Encountered a server error, please try again later.');
 
@@ -49,20 +55,25 @@ export default class AuthButton extends React.Component {
    * @override
    */
   render() {
-    let classList = 'btn btn-primary';
+    let classList = 'btn btn-purple';
+    let linkText;
+    let authLink;
     if (this.state.isFetching) {
       // The button is disabled while the authorization data is being loaded.
       classList += ' disabled';
-    }
-
-    let linkText = 'Log In';
-    let authLink = '/';
-    console.log(this.state);
-    if (!this.state.isFetching) {
+      linkText = 'Log In';
+      authLink = '/';  
+    } else {
       if (this.state.authData.authorized) {
-        authLink = this.state.authData.logoutUrl;
-        linkText = 'Log Out';
+        if (this.state.authData.hasProfile) {
+          authLink = this.state.authData.logoutUrl;
+          linkText = 'Log Out'; 
+        } else {
+          authLink = USER_SIGNUP_URL;
+          linkText = 'Create Profile';
+        }
       } else {
+        linkText = 'Log In';
         authLink = this.state.authData.loginUrl;
       }
     }

--- a/src/main/webapp/js/common/react/components/AuthButton.js
+++ b/src/main/webapp/js/common/react/components/AuthButton.js
@@ -1,7 +1,7 @@
 import checkTesting from '../../../checkTesting.js';
 import {
-  standardizeFetchErrors, 
-  makeRelativeUrlAbsolute
+  standardizeFetchErrors,
+  makeRelativeUrlAbsolute,
 } from '../../../fetch_handler.js';
 checkTesting();
 
@@ -62,12 +62,12 @@ export default class AuthButton extends React.Component {
       // The button is disabled while the authorization data is being loaded.
       classList += ' disabled';
       linkText = 'Log In';
-      authLink = '/';  
+      authLink = '/';
     } else {
       if (this.state.authData.authorized) {
         if (this.state.authData.hasProfile) {
           authLink = this.state.authData.logoutUrl;
-          linkText = 'Log Out'; 
+          linkText = 'Log Out';
         } else {
           authLink = USER_SIGNUP_URL;
           linkText = 'Create Profile';

--- a/src/main/webapp/js/common/react/components/Navbar.js
+++ b/src/main/webapp/js/common/react/components/Navbar.js
@@ -1,5 +1,6 @@
 import checkTesting from '../../../checkTesting.js';
 import NavbarLink from './NavbarLink.js';
+import AuthButton from './AuthButton.js';
 checkTesting();
 
 /**
@@ -30,6 +31,9 @@ export default function Navbar(props) {
           {props.urls.map((url, i) =>
               <NavbarLink key={i} href={url.href} name={url.name} />)}
         </ul>
+      </div>
+      <div className="ml-1">
+        <AuthButton />
       </div>
     </nav>
   );

--- a/src/main/webapp/projects.html
+++ b/src/main/webapp/projects.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
     
     <link rel="stylesheet" href="./css/projects.css"></link>
+    <link rel="stylesheet" href="./style.css"></link>
   </head>
   <body>
     <div id="navbar-container"></div>

--- a/src/main/webapp/signup.html
+++ b/src/main/webapp/signup.html
@@ -8,15 +8,16 @@
 <link rel="stylesheet" href="style.css">
 
 <div class="container">
-  <h1 class="display-4 mt-5">Sign Up for Open Sesame!</h1>
-  <h4 class="emphasis mb-5">Looking to find a mentor within the open source community, or become a mentor to foster the next generation of open source contributors? Sign up here!</h4>
+  <h1 class="display-4 mt-5">Create your Open Sesame Profile!</h1>
+  <h4 class="emphasis mb-5">Looking to find a mentor within the open source community, or become a mentor to foster the next generation of open source contributors? Create your profile to get started!</h4>
   <hr/>
   <form id="signup-form">
     <div class="form-group">
-      <button class="font-weight-bold">Link Your GitHub Account</button>
+      <button class="btn btn-purple font-weight-bold" name="github-link-button">Link Your GitHub Account</button>
       <small id="gitHubHelp" class="form-text text-muted">We will use your GitHub account to populate your name and bio and message you when you match with a mentor/mentee.</small>
     </div>
-    <div class="form-group">
+    <!-- TODO : Look into a more efficient method for adding interests. Potentially a React component. -->
+    <div id="interests" class="form-group">
       <label for="interests" class="font-weight-bold">Interests</label>
       <div class="form-check">
         <input class="form-check-input" type="checkbox" id="check1" value="python">
@@ -73,12 +74,15 @@
         </label>
       </div>
       <div class="form-check">
-        <input class="form-check-input" type="checkbox" id="check9" value="documentation">
-        <label class="form-check-label" for="check9">
+        <input class="form-check-input" type="checkbox" id="check10" value="documentation">
+        <label class="form-check-label" for="check10">
             Documentation
         </label>
       </div>
     </div>
-    <button class="btn text-center">Submit</button>
+    <button class="btn btn-purple text-center" type="submit" name="submit-button" disabled>Submit</button>
   </form>
 </div>
+
+<script src="https://www.gstatic.com/firebasejs/7.15.5/firebase.js"></script>
+<script type="module" src="./signup.js"></script>

--- a/src/main/webapp/signup.html
+++ b/src/main/webapp/signup.html
@@ -5,7 +5,7 @@
 <!-- Bootstrap CSS only -->
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
 <!-- Custom styles -->
-<link rel="stylesheet" href="style.css">
+<link rel="stylesheet" href="./css/signup.css">
 
 <div class="container">
   <h1 class="display-4 mt-5">Create your Open Sesame Profile!</h1>

--- a/src/main/webapp/signup.js
+++ b/src/main/webapp/signup.js
@@ -82,13 +82,12 @@ function submitSignup(e) {
 
     signupRequest.then((response) => {
       // If signup is successful, redirect.
-      gitHubLinkButton.disabled = false;
-      submitButton.disabled = false;
       window.location.href = AFTER_SIGNUP_REDIRECT;
     }).catch((errorResponse) => {
       console.error(
         `Error ${errorResponse.statusCode}: ${errorResponse.error}`);
       alert(errorResponse.userMessage);
+    }).then(() => {
       gitHubLinkButton.disabled = false;
       submitButton.disabled = false;
     });

--- a/src/main/webapp/signup.js
+++ b/src/main/webapp/signup.js
@@ -5,8 +5,8 @@
  */
 import {gitHubAuthorizer} from './authorization.js';
 import {
-  standardizeFetchErrors, 
-  makeRelativeUrlAbsolute
+  standardizeFetchErrors,
+  makeRelativeUrlAbsolute,
 } from './js/fetch_handler.js';
 
 const AFTER_SIGNUP_REDIRECT = '/dashboard.html';
@@ -42,7 +42,7 @@ function handleGitHubLink(e) {
 
 /**
  * Updates the signup UI when the state of user GitHub authentication changes.
- * @param {Firebase.User} user 
+ * @param {Firebase.User} user
  */
 function handleAuthStateChanged(user) {
   const signupForm = document.getElementById('signup-form');
@@ -101,16 +101,17 @@ function submitSignup(e) {
 /**
  * Creates a signup post request.
  * This requires url-encoding the signup body and formatting the errors.
- * @param {SignUpData} signupBody 
+ * @param {SignUpData} signupBody
+ * @return {Promise} Returns a prepared signup fetch request.
  */
 function createSignupRequest(signupBody) {
   const encodedBody = new URLSearchParams();
-  encodedBody.append("gitHubAuthToken", signupBody.gitHubAuthToken);
+  encodedBody.append('gitHubAuthToken', signupBody.gitHubAuthToken);
   // Appending multiple values to the same parameter is the standard protocol
   // for encoding an array of values:
   // https://stackoverflow.com/questions/38797509/passing-array-into-urlsearchparams-while-consuming-http-call-for-get-request
   signupBody.interestTags.forEach((interestTag) => {
-    encodedBody.append("interestTags", interestTag);
+    encodedBody.append('interestTags', interestTag);
   });
 
   const fetchRequest = fetch(makeRelativeUrlAbsolute('/user'), {
@@ -122,7 +123,7 @@ function createSignupRequest(signupBody) {
   });
 
   const errorFormattedFetchRequest = standardizeFetchErrors(
-      fetchRequest, 
+      fetchRequest,
       'Failed to communicate with the server. Please try again later.',
       'An error occcured while creating your account.'
           + ' Please try again later.');

--- a/src/main/webapp/signup.js
+++ b/src/main/webapp/signup.js
@@ -74,12 +74,8 @@ function submitSignup(e) {
   gitHubLinkButton.disabled = true;
   submitButton.disabled = true;
 
-  const signupBody = createSignupBody();
-  console.log('Body of signup request:');
-  console.log(signupBody);
-  if (signupBody) {
-    const signupRequest = createSignupRequest(signupBody);
-
+  const signupRequest = createSignupRequest();
+  if (signupRequest) {
     signupRequest.then((response) => {
       // If signup is successful, redirect.
       window.location.href = AFTER_SIGNUP_REDIRECT;
@@ -100,10 +96,17 @@ function submitSignup(e) {
 /**
  * Creates a signup post request.
  * This requires url-encoding the signup body and formatting the errors.
- * @param {SignUpData} signupBody
- * @return {Promise} Returns a prepared signup fetch request.
+ * @return {?Promise} Returns a prepared signup fetch request or null if the
+ *    fetch request could not be prepared.
  */
-function createSignupRequest(signupBody) {
+function createSignupRequest() {
+  const signupBody = createSignupBody();
+  console.log('Body of signup request:');
+  console.log(signupBody);
+  if (!signupBody) {
+    return null;
+  }
+
   const encodedBody = new URLSearchParams();
   encodedBody.append('gitHubAuthToken', signupBody.gitHubAuthToken);
   // Appending multiple values to the same parameter is the standard protocol
@@ -132,7 +135,7 @@ function createSignupRequest(signupBody) {
 
 /**
  * Creates the body of a signup request to be sent to the Open Sesame API.
- * @return {SignUpData} Returns the body of the signup request or null if the
+ * @return {?SignUpData} Returns the body of the signup request or null if the
  *    requirements have not been met to sign up.
  */
 function createSignupBody() {

--- a/src/main/webapp/signup.js
+++ b/src/main/webapp/signup.js
@@ -1,0 +1,161 @@
+/**
+ * @typedef SignUpData
+ * @property {string} gitHubAuthToken
+ * @property {string[]} interestTags
+ */
+import {gitHubAuthorizer} from './authorization.js';
+import {
+  standardizeFetchErrors, 
+  makeRelativeUrlAbsolute
+} from './js/fetch_handler.js';
+
+const AFTER_SIGNUP_REDIRECT = '/dashboard.html';
+
+/**
+ * Initializes the sign up form.
+ */
+function initSignupForm() {
+  const signupForm = document.getElementById('signup-form');
+  signupForm.addEventListener('submit', submitSignup);
+
+  signupForm.elements['github-link-button'].addEventListener(
+      'click', handleGitHubLink);
+  gitHubAuthorizer
+      .getFirebase().auth().onAuthStateChanged(handleAuthStateChanged);
+  // Handle auth state changed on page load in case of existing authentication.
+  handleAuthStateChanged(gitHubAuthorizer.getUser());
+}
+
+/**
+ * Handles the click event for the GitHub linking button.
+ * @param {Event} e The button click event.
+ */
+function handleGitHubLink(e) {
+  e.preventDefault();
+
+  gitHubAuthorizer.toggleSignIn().catch((error) => {
+    console.error(error);
+    alert('Encountered an error with GitHub authentication.'
+        + ' Please try again later.');
+  });
+}
+
+/**
+ * Updates the signup UI when the state of user GitHub authentication changes.
+ * @param {Firebase.User} user 
+ */
+function handleAuthStateChanged(user) {
+  const signupForm = document.getElementById('signup-form');
+  const submitButton = signupForm.elements['submit-button'];
+  const gitHubLinkButton = signupForm.elements['github-link-button'];
+  if (user) {
+    submitButton.disabled = false;
+    gitHubLinkButton.innerText = 'Unlink Your GitHub Account';
+    gitHubLinkButton.classList.add('btn-success');
+    gitHubLinkButton.classList.remove('btn-purple');
+  } else {
+    submitButton.disabled = true;
+    gitHubLinkButton.innerText = 'Link Your GitHub Account';
+    gitHubLinkButton.classList.add('btn-purple');
+    gitHubLinkButton.classList.remove('btn-success');
+  }
+}
+
+/**
+ * Validates and submits a user signup request.
+ * @param {Event} e The signup form submit event.
+ */
+function submitSignup(e) {
+  e.preventDefault();
+
+  const signupForm = document.getElementById('signup-form');
+  const gitHubLinkButton = signupForm.elements['github-link-button'];
+  const submitButton = signupForm.elements['submit-button'];
+  gitHubLinkButton.disabled = true;
+  submitButton.disabled = true;
+
+  const signupBody = createSignupBody();
+  console.log('Body of signup request:');
+  console.log(signupBody);
+  if (signupBody) {
+    const signupRequest = createSignupRequest(signupBody);
+
+    signupRequest.then((response) => {
+      // If signup is successful, redirect.
+      gitHubLinkButton.disabled = false;
+      submitButton.disabled = false;
+      window.location.href = AFTER_SIGNUP_REDIRECT;
+    }).catch((errorResponse) => {
+      console.error(
+        `Error ${errorResponse.statusCode}: ${errorResponse.error}`);
+      alert(errorResponse.userMessage);
+      gitHubLinkButton.disabled = false;
+      submitButton.disabled = false;
+    });
+  } else {
+    gitHubLinkButton.disabled = false;
+    submitButton.disabled = false;
+  }
+}
+
+/**
+ * Creates a signup post request.
+ * This requires url-encoding the signup body and formatting the errors.
+ * @param {SignUpData} signupBody 
+ */
+function createSignupRequest(signupBody) {
+  const encodedBody = new URLSearchParams();
+  encodedBody.append("gitHubAuthToken", signupBody.gitHubAuthToken);
+  // Appending multiple values to the same parameter is the standard protocol
+  // for encoding an array of values:
+  // https://stackoverflow.com/questions/38797509/passing-array-into-urlsearchparams-while-consuming-http-call-for-get-request
+  signupBody.interestTags.forEach((interestTag) => {
+    encodedBody.append("interestTags", interestTag);
+  });
+
+  const fetchRequest = fetch(makeRelativeUrlAbsolute('/user'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: encodedBody,
+  });
+
+  const errorFormattedFetchRequest = standardizeFetchErrors(
+      fetchRequest, 
+      'Failed to communicate with the server. Please try again later.',
+      'An error occcured while creating your account.'
+          + ' Please try again later.');
+
+  return errorFormattedFetchRequest;
+}
+
+/**
+ * Creates the body of a signup request to be sent to the Open Sesame API.
+ * @return {SignUpData} Returns the body of the signup request or null if the
+ *    requirements have not been met to sign up.
+ */
+function createSignupBody() {
+  if (!gitHubAuthorizer.getUser()) {
+    // TODO : Add to a more elegant notification system
+    alert('Please link your GitHub account before creating your profile.');
+    return null;
+  }
+
+  let interestCheckBox = document.getElementById('check1');
+  const interestTags = [];
+  for (let i = 2; interestCheckBox; i++) {
+    if (interestCheckBox.checked) {
+      interestTags.push(interestCheckBox.value);
+    }
+    interestCheckBox = document.getElementById(`check${i}`);
+  }
+
+  /** @type {SignUpData} */
+  return {
+    gitHubAuthToken: gitHubAuthorizer.getToken(),
+    interestTags,
+  };
+}
+
+initSignupForm();

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -9,21 +9,21 @@ a:hover,
   color: darkblue;
 }
 
-.btn {
+.btn-purple {
   background-color: rebeccapurple;
   border: none;
   border-radius: 8px;
   color: white;
 }
 
-.btn:hover {
+.btn-purple:hover {
   background-color: purple;
   border: none;
   border-radius: 8px;
   color: white;
 }
 
-.btn.disabled {
+.btn-purple.disabled {
   background-color: rebeccapurple;
   color: white;
 }


### PR DESCRIPTION
Adds the ability for a user to authenticate and create profile on the frontend.

The signup process can be broken into two distinct stages. **The important thing to consider is that the user is able to browse the website in either of these stages**, meaning that it is important to distinguish between them when writing access and authentication logic. This isn't ideal, but it is necessary after we had to abandon using OpenID due to API errors.
1. Users API authentication
2. Profile creation

Changes:
* Add `hasProfile` property to `AuthServlet` to differentiate between stages 1 and 2 in authentication.
* Update the `AuthButton` to support the stage 2 of authentication.
* Change `style.css` to allow for button colors other than purple. **The original `btn` style is now included in `btn-purple` and should be included on top of the `btn` class when making purple buttons**.
* Adds `signup.js` which drives the communication with OAuth and the Users servlet, and keeps the UI updated accordingly.

Big TODOs moving forward:
* Need to add a helper function to the users servlet that can determine if a PersonObject exists for a given User ID. This will be used for the `hasProfile` property of the `AuthServlet` response.
* Need to update the `doPost` of the Users servlet to accept the parameters sent from signup and also verify the GitHub access token.