### PR TITLE
Make ErrorResponse extend error and remove JSON formatter

### DIFF
--- a/src/main/webapp/js/common/react/components/AuthButton.js
+++ b/src/main/webapp/js/common/react/components/AuthButton.js
@@ -1,5 +1,9 @@
 import checkTesting from '../../../checkTesting.js';
-import standardizeFetchErrors from '../../../fetch_handler.js';
+import {
+  standardizeFetchErrors, 
+  defaultErrorHandling as basicErrorHandling,
+  makeRelativeUrlAbsolute,
+} from '../../../fetch_handler.js';
 checkTesting();
 
 /**
@@ -25,21 +29,19 @@ export default class AuthButton extends React.Component {
    * @override
    */
   componentDidMount() {
-    const fetchRequest = standardizeFetchErrors(fetch('/auth'),
+    const fetchRequest = standardizeFetchErrors(
+        fetch(makeRelativeUrlAbsolute('/auth')),
         'Failed to communicate with the server, please try again later.',
         'Encountered a server error, please try again later.');
-
-    fetchRequest.then((authData) => {
+    
+    fetchRequest.then((response) => response.json()).then((authData) => {
       console.log('Auth data received:');
       console.log(authData);
       this.setState({
         isFetching: false,
         authData,
       });
-    }).catch((errorResponse) => {
-      console.error(
-          `Error ${errorResponse.statusCode}: ${errorResponse.error}`);
-    });
+    }).catch((error) => basicErrorHandling(error));
   }
 
   /**

--- a/src/main/webapp/js/common/react/components/AuthButton.js
+++ b/src/main/webapp/js/common/react/components/AuthButton.js
@@ -1,7 +1,7 @@
 import checkTesting from '../../../checkTesting.js';
 import {
   standardizeFetchErrors, 
-  defaultErrorHandling as basicErrorHandling,
+  basicErrorHandling,
   makeRelativeUrlAbsolute,
 } from '../../../fetch_handler.js';
 checkTesting();

--- a/src/main/webapp/js/fetch_handler.js
+++ b/src/main/webapp/js/fetch_handler.js
@@ -7,7 +7,7 @@
  * All error responses from the Open Sesame API should contain a JSON body
  * formatted to match the ErrorResponse class.
  */
-export class ErrorResponse extends Error {
+class ErrorResponse extends Error {
   /**
    * Creates a JS error with additional information for frontend use.
    * @param {string} message
@@ -46,7 +46,7 @@ export class ErrorResponse extends Error {
  * @return {Promise} Returns a promise that formats the errors from a fetch
  *    request.
  */
-export function standardizeFetchErrors(
+function standardizeFetchErrors(
     fetchRequest, fetchFailedUserMessage, genericServerErrorUserMessage) {
   return fetchRequest.catch((fetchError) => {
     // Fetch encountered an error while making the request (a network
@@ -59,7 +59,7 @@ export function standardizeFetchErrors(
       // an error code.
       return formatAPIErrorResponse(response, genericServerErrorUserMessage);
     } else {
-      return response.json();
+      return response;
     }
   });
 }
@@ -71,8 +71,20 @@ export function standardizeFetchErrors(
  * @param {string} relativeUrl
  * @return {URL} Returns the absolute URL.
  */
-export function makeRelativeUrlAbsolute(relativeUrl) {
+function makeRelativeUrlAbsolute(relativeUrl) {
   return new URL(relativeUrl, window.location.origin);
+}
+
+/**
+ * Logs the error to the console and alerts the user through a browser alert if
+ * there is a user message available.
+ * @param {Error} error
+ */
+function basicErrorHandling(error) {
+  console.error(error);
+  if (typeof(error.userMessage) !== 'undefined') {
+    alert(error.userMessage);
+  }
 }
 
 /**
@@ -128,3 +140,10 @@ function extractErrorTextFromHTML(htmlString) {
   return Array.from(body.childNodes)
       .map((child) => child.textContent).join(' ');
 }
+
+export {
+  ErrorResponse,
+  standardizeFetchErrors,
+  makeRelativeUrlAbsolute,
+  basicErrorHandling,
+};

--- a/src/main/webapp/js/fetch_handler.test.js
+++ b/src/main/webapp/js/fetch_handler.test.js
@@ -9,7 +9,7 @@ afterEach(() => {
   fetchMock.restore();
 });
 
-describe('Fetch error handler', () => {
+describe('Fetch error standardizer', () => {
   it('correctly formats fetch errors', () => {
     fetchMock.get('https://localhost/test', {
       throws: new Error('Test error'),
@@ -122,7 +122,7 @@ describe('Fetch error handler', () => {
       fetchFailedMessage,
       genericServerErrorMessage);
 
-    return formattedRequest.then((json) => {
+    return formattedRequest.then((response) => response.json()).then((json) => {
       expect(json.message).toEqual('Test response');
     }).catch((errorResponse) => {
       fail('Caught an error from a successful request.');

--- a/src/main/webapp/js/fetch_handler.test.js
+++ b/src/main/webapp/js/fetch_handler.test.js
@@ -12,7 +12,7 @@ afterEach(() => {
 describe('Fetch error handler', () => {
   it('correctly formats fetch errors', () => {
     fetchMock.get('https://localhost/test', {
-      throws: 'Test error',
+      throws: new Error('Test error'),
     });
 
     const formattedRequest = standardizeFetchErrors(
@@ -23,9 +23,9 @@ describe('Fetch error handler', () => {
     return formattedRequest.then((res) => {
       fail('Did not catch the error.');
     }).catch((errorResponse) => {
-      expect(errorResponse.error).toEqual('Test error');
+      expect(errorResponse.message).toEqual('Test error');
       expect(errorResponse.userMessage).toEqual(fetchFailedMessage);
-      expect(errorResponse.statusCode).toBeUndefined();
+      expect(errorResponse.statusCode).toBeNull();
     });
   });
 
@@ -46,7 +46,7 @@ describe('Fetch error handler', () => {
     return formattedRequest.then((res) => {
       fail('Did not catch the error.');
     }).catch((errorResponse) => {
-      expect(errorResponse.error).toEqual('Error message');
+      expect(errorResponse.message).toEqual('Error message');
       expect(errorResponse.userMessage).toEqual(genericServerErrorMessage);
       expect(errorResponse.statusCode).toEqual(500);
     });
@@ -54,7 +54,7 @@ describe('Fetch error handler', () => {
 
   it('correctly formats API errors', () => {
     const apiErrorResponse = {
-      error: 'Test API error',
+      message: 'Test API error',
       statusCode: 400,
       userMessage: 'Test user message',
     };
@@ -75,7 +75,7 @@ describe('Fetch error handler', () => {
     return formattedRequest.then((res) => {
       fail('Did not catch the error.');
     }).catch((errorResponse) => {
-      expect(errorResponse.error).toEqual('Test API error');
+      expect(errorResponse.message).toEqual('Test API error');
       expect(errorResponse.userMessage).toEqual('Test user message');
       expect(errorResponse.statusCode).toEqual(400);
     });
@@ -97,7 +97,7 @@ describe('Fetch error handler', () => {
     return formattedRequest.then((res) => {
       fail('Did not catch the error.');
     }).catch((errorResponse) => {
-      expect(errorResponse.error)
+      expect(errorResponse.message)
           .toEqual('Error could not be parsed; unanticipated content type.');
       expect(errorResponse.userMessage).toEqual(genericServerErrorMessage);
       expect(errorResponse.statusCode).toEqual(500);

--- a/src/main/webapp/js/projects/react/components/ProjectsSearch.js
+++ b/src/main/webapp/js/projects/react/components/ProjectsSearch.js
@@ -5,7 +5,8 @@
 import ProjectList from './ProjectList.js';
 import {
   standardizeFetchErrors,
-  makeRelativeUrlAbsolute
+  makeRelativeUrlAbsolute,
+  basicErrorHandling,
 } from '../../../fetch_handler.js';
 
 /**
@@ -34,18 +35,15 @@ export default class ProjectsSearch extends React.Component {
         fetch(makeRelativeUrlAbsolute('/project-previews')),
         'Failed to communicate with the server, please try again later.',
         'Encountered a server error, please try again later.');
-    fetchRequest.then((projectPreviews) => {
+
+    fetchRequest.then((response) => response.json()).then((projectPreviews) => {
       console.log('Project Previews Received:');
       console.log(projectPreviews);
       this.setState({
         isFetching: false,
         projectPreviews,
       });
-    }).catch((errorResponse) => {
-      alert(errorResponse.userMessage);
-      console.error(
-          `Error ${errorResponse.statusCode}: ${errorResponse.error}`);
-    });
+    }).catch((error) => basicErrorHandling(error));
   }
 
   /**


### PR DESCRIPTION
To comply with [the Google JS Style guide](https://google.github.io/styleguide/jsguide.html#features-exceptions) and satisfy the new Linter, made the errors thrown from the fetch error handler extend the `Error` class. Also, removed the automatic JSON formatting of the response so that it can be used for non-JSON data requests.