### PR TITLE
Add email field to user signup

### DIFF
--- a/src/main/webapp/js/common/react/components/Navbar.js
+++ b/src/main/webapp/js/common/react/components/Navbar.js
@@ -1,5 +1,6 @@
 import checkTesting from '../../../checkTesting.js';
 import NavbarLink from './NavbarLink.js';
+import AuthButton from './AuthButton.js';
 checkTesting();
 
 /**
@@ -30,6 +31,9 @@ export default function Navbar(props) {
           {props.urls.map((url, i) =>
             <NavbarLink key={i} href={url.href} name={url.name} />)}
         </ul>
+      </div>
+      <div className="ml-1">
+        <AuthButton />
       </div>
     </nav>
   );

--- a/src/main/webapp/signup.html
+++ b/src/main/webapp/signup.html
@@ -16,6 +16,13 @@
       <button class="btn btn-purple font-weight-bold" name="github-link-button">Link Your GitHub Account</button>
       <small id="gitHubHelp" class="form-text text-muted">We will use your GitHub account to populate your name and bio and message you when you match with a mentor/mentee.</small>
     </div>
+    <form>
+    <div class="form-group">
+      <label for="userEmail" class="font-weight-bold">Email address</label>
+      <input type="email" class="form-control" id="userEmail" name="userEmail" aria-describedby="emailHelp" placeholder="Enter email" required>
+      <!-- TODO : Change privacy statement when matchmaking process is developed beyond MVP -->
+      <small id="emailHelp" class="form-text text-muted">Your email address is not public. It is only visible to Open Sesame users if you're seeking to mentor.</small>
+    </div>
     <!-- TODO : Look into a more efficient method for adding interests. Potentially a React component. -->
     <div id="interests" class="form-group">
       <label for="interests" class="font-weight-bold">Interests</label>

--- a/src/main/webapp/signup.js
+++ b/src/main/webapp/signup.js
@@ -2,6 +2,7 @@
  * @typedef SignUpData
  * @property {string} gitHubAuthToken
  * @property {string[]} interestTags
+ * @property {string} emailAddress
  */
 import {gitHubAuthorizer} from './authorization.js';
 import {
@@ -145,6 +146,14 @@ function createSignupBody() {
     return null;
   }
 
+  const emailAddress = 
+      document.getElementById('signup-form').elements['userEmail'].value;
+  if (!validateEmail(emailAddress)) {
+    // TODO : Add to a more elegant notification system
+    alert('Please enter a valid email address.');
+    return null;
+  }
+
   let interestCheckBox = document.getElementById('check1');
   const interestTags = [];
   for (let i = 2; interestCheckBox; i++) {
@@ -158,7 +167,19 @@ function createSignupBody() {
   return {
     gitHubAuthToken: gitHubAuthorizer.getToken(),
     interestTags,
+    emailAddress,
   };
+}
+
+/**
+ * Validates an email syntactically against a regular expression.
+ * Sourced from:
+ * https://stackoverflow.com/questions/46155/how-to-validate-an-email-address-in-javascript
+ * @param {string} email 
+ */
+function validateEmail(email) {
+  const re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+  return re.test(String(email).toLowerCase());
 }
 
 initSignupForm();

--- a/src/main/webapp/signup.js
+++ b/src/main/webapp/signup.js
@@ -148,11 +148,6 @@ function createSignupBody() {
 
   const emailAddress = 
       document.getElementById('signup-form').elements['userEmail'].value;
-  if (!validateEmail(emailAddress)) {
-    // TODO : Add to a more elegant notification system
-    alert('Please enter a valid email address.');
-    return null;
-  }
 
   let interestCheckBox = document.getElementById('check1');
   const interestTags = [];
@@ -169,17 +164,6 @@ function createSignupBody() {
     interestTags,
     emailAddress,
   };
-}
-
-/**
- * Validates an email syntactically against a regular expression.
- * Sourced from:
- * https://stackoverflow.com/questions/46155/how-to-validate-an-email-address-in-javascript
- * @param {string} email 
- */
-function validateEmail(email) {
-  const re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-  return re.test(String(email).toLowerCase());
 }
 
 initSignupForm();


### PR DESCRIPTION
Add an email field to user signup. This includes basic syntactic validation of the email on the client side, but **should also be validated on the server-side before the client data is saved**. 

This field was added following a design decision to avoid using the email associated with someone's GitHub account. We hope to provide more flexibility to users by allowing them to choose what email to use as their point of contact.