### PR TITLE
Add authentication redirect and add to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,20 @@ Java unit testing is done with [JUnit 4](https://junit.org/junit4/).
 **To add another JS test**, simply add a JS file that ends with `.test.js` (ex: `script.test.js`) and it will automatically be run by Jest.
 **To add another Java test**, add a Java file to the testing directory `src/test/java/`. Be sure to follow the Java conventions for package directory structure, for example if you're testing a package in `com.google.opensesame.github`, the test should be placed in the directory `src/test/java/com/google/opensesame/github`.
 
+## User Authentication and Sign Up
+User signup consists of three parts:
+1. Website authentication (a user creates an account on our website)
+  * This is done using the [Users API](https://cloud.google.com/appengine/docs/standard/java/users)
+  * In the future this could be migrated to the [Firebase Admin SDK](https://firebase.google.com/docs/reference/admin) or similar OAuth-based authentication API such that GitHub authentication and website authentication could become a single step.
+2. GitHub authentication (a user verifies ownership of a GitHub account, which is then linked with the account on our website)
+  * This is done using [Firebase Authentication](https://firebase.google.com/docs/auth) with [GitHub OAuth](https://docs.github.com/en/developers/apps/about-apps#about-oauth-apps)
+  * An access token is granted to the user, which is then sent to the server during the profile creation step and verified on the backend. 
+  * Once the access token is verified, the user has proven ownership of that GitHub account, and it is then stored by ID in the website profile.
+3. Profile creation (a user with an authorized account can add more information about themselves)
+  * After a user completes website authentication, they are redirected to a form for profile creation.
+  * GitHub authentication is completed during profile creation.
+
+A user is only considered to have an account on Open Sesame if they have completed all three steps outlined above.
+
 ## File Structure
 Please refer to [this](https://maven.apache.org/guides/introduction/introduction-to-the-standard-directory-layout.html) resource to learn more about what each project directory should be used for, and take a look at [this section](https://maven.apache.org/guides/getting-started/#how-do-i-make-my-first-maven-project) of the Maven getting started guide to see how the project naming scheme affects directory structure.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ User signup consists of three parts:
   * This is done using [Firebase Authentication](https://firebase.google.com/docs/auth) with [GitHub OAuth](https://docs.github.com/en/developers/apps/about-apps#about-oauth-apps)
   * An access token is granted to the user, which is then sent to the server during the profile creation step and verified on the backend. 
   * Once the access token is verified, the user has proven ownership of that GitHub account, and it is then stored by ID in the website profile.
-3. Profile creation (a user with an authorized account can add more information about themselves)
+3. Profile creation (a user with an authorized account can add more information about themselves, such as interest tags)
   * After a user completes website authentication, they are redirected to a form for profile creation.
   * GitHub authentication is completed during profile creation.
 

--- a/src/main/java/com/google/opensesame/auth/AuthServlet.java
+++ b/src/main/java/com/google/opensesame/auth/AuthServlet.java
@@ -16,7 +16,7 @@ import javax.servlet.http.HttpServletResponse;
 
 @WebServlet("/auth")
 public class AuthServlet extends HttpServlet {
-  public static final String AUTH_URL_REDIRECT = "/";
+  public static final String AUTH_URL_REDIRECT = "/sign_in_redirect.html";
 
   public Gson gson = new Gson();
 

--- a/src/main/webapp/js/auth_check.js
+++ b/src/main/webapp/js/auth_check.js
@@ -1,0 +1,67 @@
+import {
+  standardizeFetchErrors,
+  makeRelativeUrlAbsolute,
+} from './fetch_handler.js';
+
+/**
+ * Creates the authentication fetch request.
+ * @return {Promise} Returns the authentication fetch request. 
+ */
+function createAuthFetch() {
+  const errorFormattedRequest = standardizeFetchErrors(
+      fetch(makeRelativeUrlAbsolute('/auth')),
+      "Failed to communicate with authentication server.",
+      "Failed to verify authentication.");
+  return errorFormattedRequest
+      .then((response) => response.json()).then((authData) => {
+    // Any uses of authDataFetch after the fetch request has already been
+    // completed will immediately resolve with the authentication data.
+    authDataFetch = Promise.resolve(authData);
+    return authData;
+  }).catch((errorResponse) => {
+    // Any uses of authDataFetch after the fetch request has already failed
+    // will immediately reject with the error.
+    authDataFetch = Promise.reject(errorResponse);
+    return Promise.reject(errorResponse);
+  });
+}
+
+/**
+ * A promise that returns the authentication data. This is useful if you need
+ * to define more advanced behavior with the authentication data. 
+ * @type {Promise}
+ */
+export let authDataFetch = createAuthFetch();
+/**
+ * Performs an authentication check and redirects if the user is not
+ * authenticated. If a no profile redirect is not provided, the user will be
+ * logged out in the event that they do not have a profile.
+ * @param {string} [noAuthRedirect=null] Where to redirect if the user is not
+ *    authenticated. By default the user will not be redirected.
+ * @param {string} [authRedirect=null] Where to redirect if the user is
+ *    authenticated. By default the user will not be redirected.
+ * @param {string} [noProfileRedirect=null] Where to redirect if the user does
+ *    not have a profile. By default the user wil not be redirected.
+ * @return {Promise} Returns a promise for the authentication check.
+ */
+export function authRedirect(
+    noAuthRedirect = null, authRedirect = null, noProfileRedirect = null) {
+  return authDataFetch.then((authData) => {
+    if (authData.authorized) {
+      if (!authData.hasProfile) {
+        if (noProfileRedirect) {
+          window.location.href = noProfileRedirect;
+        }
+      } else if (authRedirect) {
+        window.location.href = authRedirect;
+      }
+    } else if (noAuthRedirect) {
+      window.location.href = noAuthRedirect;
+    }
+  }).catch((errorRespone) => {
+    console.error(errorRespone);
+    if (noAuthRedirect) {
+      window.location.href = noAuthRedirect;
+    }
+  });
+}

--- a/src/main/webapp/js/auth_check.js
+++ b/src/main/webapp/js/auth_check.js
@@ -33,6 +33,7 @@ function createAuthFetch() {
  * @type {Promise}
  */
 export let authDataFetch = createAuthFetch();
+
 /**
  * Performs an authentication check and redirects if the user is not
  * authenticated. If a no profile redirect is not provided, the user will be

--- a/src/main/webapp/js/auth_check.js
+++ b/src/main/webapp/js/auth_check.js
@@ -27,8 +27,9 @@ function createAuthFetch() {
 }
 
 /**
- * A promise that returns the authentication data. This is useful if you need
- * to define more advanced behavior with the authentication data. 
+ * A promise that returns the authentication data once it has been fetched.
+ * This is useful if you need to define more advanced behavior with the
+ * authentication data. 
  * @type {Promise}
  */
 export let authDataFetch = createAuthFetch();

--- a/src/main/webapp/js/auth_check.js
+++ b/src/main/webapp/js/auth_check.js
@@ -5,31 +5,31 @@ import {
 
 /**
  * Creates the authentication fetch request.
- * @return {Promise} Returns the authentication fetch request. 
+ * @return {Promise} Returns the authentication fetch request.
  */
 function createAuthFetch() {
   const errorFormattedRequest = standardizeFetchErrors(
       fetch(makeRelativeUrlAbsolute('/auth')),
-      "Failed to communicate with authentication server.",
-      "Failed to verify authentication.");
+      'Failed to communicate with authentication server.',
+      'Failed to verify authentication.');
   return errorFormattedRequest
       .then((response) => response.json()).then((authData) => {
-    // Any uses of authDataFetch after the fetch request has already been
-    // completed will immediately resolve with the authentication data.
-    authDataFetch = Promise.resolve(authData);
-    return authData;
-  }).catch((errorResponse) => {
-    // Any uses of authDataFetch after the fetch request has already failed
-    // will immediately reject with the error.
-    authDataFetch = Promise.reject(errorResponse);
-    return Promise.reject(errorResponse);
-  });
+        // Any uses of authDataFetch after the fetch request has already been
+        // completed will immediately resolve with the authentication data.
+        authDataFetch = Promise.resolve(authData);
+        return authData;
+      }).catch((errorResponse) => {
+        // Any uses of authDataFetch after the fetch request has already failed
+        // will immediately reject with the error.
+        authDataFetch = Promise.reject(errorResponse);
+        return Promise.reject(errorResponse);
+      });
 }
 
 /**
  * A promise that returns the authentication data once it has been fetched.
  * This is useful if you need to define more advanced behavior with the
- * authentication data. 
+ * authentication data.
  * @type {Promise}
  */
 export let authDataFetch = createAuthFetch();

--- a/src/main/webapp/js/common/react/display_navbar.js
+++ b/src/main/webapp/js/common/react/display_navbar.js
@@ -7,10 +7,7 @@
  */
 import Navbar from './components/Navbar.js';
 import {DataFetcher} from './components/DataFetcher.js';
-import {
-  standardizeFetchErrors,
-  makeRelativeUrlAbsolute,
-} from '../../fetch_handler.js';
+import {authDataFetch} from '../../auth_check.js';
 
 const urls = [
   {
@@ -42,7 +39,7 @@ function initNavbar() {
   const navbarContainer = document.getElementById('navbar-container');
   ReactDOM.render(
       <DataFetcher
-        createFetchRequest={createAuthFetchRequest}
+        createFetchRequest={() => authDataFetch}
         render={renderNavbar} />,
       navbarContainer);
 }
@@ -59,24 +56,6 @@ function renderNavbar(dataFetcher) {
       loading={dataFetcher.isFetching}
       authData={dataFetcher.data} />
   );
-}
-
-/**
- * Creates a fetch request to get the authentication status of the user.
- * @param {AbortSignal} signal
- * @return {Promise} Returns the authentication fetch request.
- */
-function createAuthFetchRequest(signal) {
-  const fetchRequest = fetch(makeRelativeUrlAbsolute('/auth'), {
-    method: 'GET',
-    signal: signal,
-  });
-
-  return standardizeFetchErrors(
-      fetchRequest,
-      'Failed to communicate with the server, please try again later.',
-      'Encountered a server error, please try again later.')
-      .then((response) => response.json());
 }
 
 initNavbar();

--- a/src/main/webapp/js/default_auth_redirect.js
+++ b/src/main/webapp/js/default_auth_redirect.js
@@ -1,0 +1,10 @@
+/**
+ * @fileoverview This is a convenience module that implements the default
+ * redirect behavior of an authenticated-only page. If a user is not authorized,
+ * they are redirected to the home page. If a user is authorized but has not yet
+ * completed profile creation, they are redirected to the profile creation page.
+ * If a user is authorized and has a profile, they are not redirected.
+ */
+import {authRedirect} from './auth_check.js';
+
+authRedirect('/', null, '/signup.html');

--- a/src/main/webapp/projects.html
+++ b/src/main/webapp/projects.html
@@ -14,6 +14,9 @@
   <body>
     <div id="navbar-container"></div>
     <div id="projects-container"></div>
+    <noscript>
+      Please enable JavaScript to use this website.
+    </noscript>
 
     <!-- Bootstrap Scripts -->
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>

--- a/src/main/webapp/sign_in_redirect.html
+++ b/src/main/webapp/sign_in_redirect.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Sign In</title>
+  <script type="module" src="./sign_in_redirect.js"></script>
+</head>
+</html>

--- a/src/main/webapp/sign_in_redirect.html
+++ b/src/main/webapp/sign_in_redirect.html
@@ -4,4 +4,9 @@
   <title>Sign In</title>
   <script type="module" src="./sign_in_redirect.js"></script>
 </head>
+<body>
+  <noscript>
+    Please enable JavaScript to use this website.
+  </noscript>
+</body>
 </html>

--- a/src/main/webapp/sign_in_redirect.js
+++ b/src/main/webapp/sign_in_redirect.js
@@ -1,3 +1,3 @@
-import {authRedirect} from './js/auth_check.js';
+import {authRedirect} from './js-build/auth_check.js';
 
 authRedirect('/', '/dashboard.html', '/signup.html');

--- a/src/main/webapp/sign_in_redirect.js
+++ b/src/main/webapp/sign_in_redirect.js
@@ -1,0 +1,3 @@
+import {authRedirect} from './js/auth_check.js';
+
+authRedirect('/', '/dashboard.html', '/signup.html');


### PR DESCRIPTION
Add authentication redirect and authentication data fetching to a module for easy access and to avoid repeated calls to the authentication servlet on the same page.

* Add information about the user signup flow to the README
* Create a `sign_in_redirect.html` page that redirects users after logging in with the Users API
* Add `auth_check.js` module that gets authentication data from the servlet and provides a helper function for redirecting based on that data.
* Change the Navbar to reuse the authentication data present in `auth_check.js`.
* Create `default_auth_redirect.js`, a convenience module that implements the default redirect behavior for an authenticated-only page.
* Add checks for no JavaScript to the redirect page and the projects page.

closes #101 