### PR TITLE
Remove default exports

### DIFF
--- a/src/main/webapp/js/checkTesting.js
+++ b/src/main/webapp/js/checkTesting.js
@@ -17,7 +17,7 @@
  * allows modules to be imported from a browser context in the same way that
  * they are imported below, instead of via script tags in the HTML document.
  */
-export default function checkTesting() {
+export function checkTesting() {
   if ((typeof process !== 'undefined') && (process.release.name === 'node')) {
     global.PropTypes = require('prop-types');
     global.React = require('react');

--- a/src/main/webapp/js/common/react/components/AuthButton.js
+++ b/src/main/webapp/js/common/react/components/AuthButton.js
@@ -10,7 +10,7 @@ const USER_SIGNUP_URL = '/signup.html';
  * @param {Object} props
  * @return {React.Component} Returns the React component.
  */
-export default function AuthButton(props) {
+export function AuthButton(props) {
   const authData = props.authData;
 
   let classList = 'btn btn-emphasis';

--- a/src/main/webapp/js/common/react/components/AuthButton.js
+++ b/src/main/webapp/js/common/react/components/AuthButton.js
@@ -1,4 +1,4 @@
-import checkTesting from '../../../checkTesting.js';
+import {checkTesting} from '../../../checkTesting.js';
 import {authDataType} from '../navbar_prop_types.js';
 checkTesting();
 

--- a/src/main/webapp/js/common/react/components/DataFetcher.js
+++ b/src/main/webapp/js/common/react/components/DataFetcher.js
@@ -40,7 +40,7 @@
  * @property {function(AbortSignal): Promise} createFetchRequest
  * @property {function(DataFetcherState): React.Component} render
  */
-import checkTesting from '../../../checkTesting.js';
+import {checkTesting} from '../../../checkTesting.js';
 import {basicErrorHandling} from '../../../fetch_handler.js';
 checkTesting();
 

--- a/src/main/webapp/js/common/react/components/Navbar.js
+++ b/src/main/webapp/js/common/react/components/Navbar.js
@@ -1,4 +1,4 @@
-import checkTesting from '../../../checkTesting.js';
+import {checkTesting} from '../../../checkTesting.js';
 import NavbarLink from './NavbarLink.js';
 import AuthButton from './AuthButton.js';
 import {authDataType, navbarLinkType} from '../navbar_prop_types.js';

--- a/src/main/webapp/js/common/react/components/Navbar.js
+++ b/src/main/webapp/js/common/react/components/Navbar.js
@@ -1,6 +1,6 @@
 import {checkTesting} from '../../../checkTesting.js';
 import NavbarLink from './NavbarLink.js';
-import AuthButton from './AuthButton.js';
+import {AuthButton} from './AuthButton.js';
 import {authDataType, navbarLinkType} from '../navbar_prop_types.js';
 checkTesting();
 

--- a/src/main/webapp/js/common/react/components/Navbar.js
+++ b/src/main/webapp/js/common/react/components/Navbar.js
@@ -1,5 +1,5 @@
 import {checkTesting} from '../../../checkTesting.js';
-import NavbarLink from './NavbarLink.js';
+import {NavbarLink} from './NavbarLink.js';
 import {AuthButton} from './AuthButton.js';
 import {authDataType, navbarLinkType} from '../navbar_prop_types.js';
 checkTesting();

--- a/src/main/webapp/js/common/react/components/Navbar.js
+++ b/src/main/webapp/js/common/react/components/Navbar.js
@@ -21,7 +21,7 @@ checkTesting();
  * @param {NavbarProps} props
  * @return {React.Component} Returns the navbar.
  */
-export default function Navbar(props) {
+export function Navbar(props) {
   const authenticated =
       !props.loading && props.authData.authorized && props.authData.hasProfile;
 

--- a/src/main/webapp/js/common/react/components/NavbarLink.js
+++ b/src/main/webapp/js/common/react/components/NavbarLink.js
@@ -1,4 +1,4 @@
-import checkTesting from '../../../checkTesting.js';
+import {checkTesting} from '../../../checkTesting.js';
 import {navbarLinkType} from '../navbar_prop_types.js';
 checkTesting();
 

--- a/src/main/webapp/js/common/react/components/NavbarLink.js
+++ b/src/main/webapp/js/common/react/components/NavbarLink.js
@@ -7,7 +7,7 @@ checkTesting();
  * @param {{url: NavbarLink}} props
  * @return {React.Component} Returns the navbar link.
  */
-export default function NavbarLink(props) {
+export function NavbarLink(props) {
   const url = props.url;
 
   let classes = 'nav-item';

--- a/src/main/webapp/js/common/react/display_navbar.js
+++ b/src/main/webapp/js/common/react/display_navbar.js
@@ -5,7 +5,7 @@
  * Also, be sure to add a div with the ID "navbar-container". This
  * is where the Navbar will be rendered to.
  */
-import Navbar from './components/Navbar.js';
+import {Navbar} from './components/Navbar.js';
 import {DataFetcher} from './components/DataFetcher.js';
 import {
   standardizeFetchErrors,

--- a/src/main/webapp/js/common/react/navbar_prop_types.js
+++ b/src/main/webapp/js/common/react/navbar_prop_types.js
@@ -1,4 +1,4 @@
-import checkTesting from '../../checkTesting.js';
+import {checkTesting} from '../../checkTesting.js';
 checkTesting();
 
 export const authDataType = PropTypes.shape({

--- a/src/main/webapp/js/common/react/tests/Navbar.test.js
+++ b/src/main/webapp/js/common/react/tests/Navbar.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Navbar from '../components/Navbar.js';
+import {Navbar} from '../components/Navbar.js';
 import '@testing-library/jest-dom/extend-expect';
 import {render, screen} from '@testing-library/react';
 

--- a/src/main/webapp/js/common/react/tests/NavbarLink.test.js
+++ b/src/main/webapp/js/common/react/tests/NavbarLink.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import NavbarLink from '../components/NavbarLink.js';
+import {NavbarLink} from '../components/NavbarLink.js';
 import '@testing-library/jest-dom/extend-expect';
 import {render, screen} from '@testing-library/react';
 

--- a/src/main/webapp/js/projects/react/components/ExpandedProject.js
+++ b/src/main/webapp/js/projects/react/components/ExpandedProject.js
@@ -1,5 +1,5 @@
-import TagList from './TagList.js';
-import MentorCard from './MentorCard.js';
+import {TagList} from './TagList.js';
+import {MentorCard} from './MentorCard.js';
 import {expandedProjectType} from '../prop_types.js';
 
 /**

--- a/src/main/webapp/js/projects/react/components/ExpandedProject.js
+++ b/src/main/webapp/js/projects/react/components/ExpandedProject.js
@@ -38,7 +38,7 @@ export function ExpandedProject(props) {
           <div className="d-flex flex-wrap mb-2">
             {project.mentors.map((mentor) => {
               return (
-                <div className="p-1 col-lg-3" key={mentor.userId}>
+                <div className="p-1 col-lg-3" key={mentor.userID}>
                   <MentorCard mentor={mentor} />
                 </div>
               );

--- a/src/main/webapp/js/projects/react/components/ExpandedProject.js
+++ b/src/main/webapp/js/projects/react/components/ExpandedProject.js
@@ -7,7 +7,7 @@ import {expandedProjectType} from '../prop_types.js';
  * @param {Object} props
  * @return {React.Component} Returns the React component.
  */
-export default function ExpandedProject(props) {
+export function ExpandedProject(props) {
   if (props.loading) {
     return (
       <h2 className="text-center mt-1">Loading project...</h2>

--- a/src/main/webapp/js/projects/react/components/MentorCard.js
+++ b/src/main/webapp/js/projects/react/components/MentorCard.js
@@ -1,12 +1,12 @@
 import {mentorType} from '../prop_types.js';
-import TagList from './TagList.js';
+import {TagList} from './TagList.js';
 
 /**
  * A card to display basic information about a project mentor.
  * @param {Object} props
  * @return {React.Component} Returns the react component.
  */
-export default function MentorCard(props) {
+export function MentorCard(props) {
   const mentor = props.mentor;
 
   return (

--- a/src/main/webapp/js/projects/react/components/ProjectList.js
+++ b/src/main/webapp/js/projects/react/components/ProjectList.js
@@ -1,4 +1,4 @@
-import ProjectPreview from './ProjectPreview.js';
+import {ProjectPreview} from './ProjectPreview.js';
 import {projectPreviewType} from '../prop_types.js';
 
 /**
@@ -15,7 +15,7 @@ import {projectPreviewType} from '../prop_types.js';
  * @return {React.Component} Returns a React component which is a list of
  * project previews.
  */
-export default function ProjectList(props) {
+export function ProjectList(props) {
   if (props.loading) {
     return (
       <h2 className="text-center mt-1">Loading projects...</h2>

--- a/src/main/webapp/js/projects/react/components/ProjectPreview.js
+++ b/src/main/webapp/js/projects/react/components/ProjectPreview.js
@@ -1,4 +1,4 @@
-import TagList from './TagList.js';
+import {TagList} from './TagList.js';
 import {projectPreviewType} from '../prop_types.js';
 
 const Link = ReactRouterDOM.Link;
@@ -8,7 +8,7 @@ const Link = ReactRouterDOM.Link;
  * @param {{projectPreview: ProjectPreviewData}} props
  * @return {React.Component} Returns a React component project preview card.
  */
-export default function ProjectPreview(props) {
+export function ProjectPreview(props) {
   const projectPreview = props.projectPreview;
   const projectTags = projectPreview.topicTags;
   // Adds the primary language to the list of project tags. Should add

--- a/src/main/webapp/js/projects/react/components/ProjectsSearch.js
+++ b/src/main/webapp/js/projects/react/components/ProjectsSearch.js
@@ -2,13 +2,13 @@
  * @fileoverview The highest-order component of the mentored project search
  * page. This handles the loading of project preview data.
  */
-import ProjectList from './ProjectList.js';
+import {ProjectList} from './ProjectList.js';
 import {
   standardizeFetchErrors,
   makeRelativeUrlAbsolute,
 } from '../../../fetch_handler.js';
 import {DataFetcher} from '../../../common/react/components/DataFetcher.js';
-import ExpandedProject from './ExpandedProject.js';
+import {ExpandedProject} from './ExpandedProject.js';
 
 // Using HashRouter instead of standard BrowserRouter because it supports
 // client-side routing that doesn't interfere with server-side
@@ -22,7 +22,7 @@ const Route = ReactRouterDOM.Route;
  * The main project search page react component.
  * @extends React.Component
  */
-export default class ProjectsSearch extends React.Component {
+export class ProjectsSearch extends React.Component {
   /**
    * Create the projects search page react component.
    * @param {{}} props

--- a/src/main/webapp/js/projects/react/components/TagList.js
+++ b/src/main/webapp/js/projects/react/components/TagList.js
@@ -3,7 +3,7 @@
  * @param {{tags: string[]}} props
  * @return {React.Component} Returns a React component list of tags.
  */
-export default function TagList(props) {
+export function TagList(props) {
   return (
     <div className="d-flex flex-wrap">
       {props.tags.map((tag, i) => {

--- a/src/main/webapp/js/projects/react/projects_search.js
+++ b/src/main/webapp/js/projects/react/projects_search.js
@@ -1,4 +1,4 @@
-import ProjectsSearch from './components/ProjectsSearch.js';
+import {ProjectsSearch} from './components/ProjectsSearch.js';
 
 const projectsContainer = document.getElementById('projects-container');
 ReactDOM.render(<ProjectsSearch />, projectsContainer);


### PR DESCRIPTION
Remove default exports to comply with the [Google JS style guide](https://google.github.io/styleguide/jsguide.html#es-module-exports).

Also, this fixes a small bug with React keys caused by an ID being called `mentorID` instead of `mentorId`. We should probably find some consistency there and stick with it.